### PR TITLE
NullPointerException on (De)Serializers

### DIFF
--- a/src/main/java/io/vertx/kafka/client/BufferDeserializer.java
+++ b/src/main/java/io/vertx/kafka/client/BufferDeserializer.java
@@ -16,6 +16,9 @@ public class BufferDeserializer implements Deserializer<Buffer> {
 
   @Override
   public Buffer deserialize(String topic, byte[] data) {
+    if (data == null)
+      return null;
+
     return Buffer.buffer(data);
   }
 

--- a/src/main/java/io/vertx/kafka/client/BufferSerializer.java
+++ b/src/main/java/io/vertx/kafka/client/BufferSerializer.java
@@ -16,6 +16,9 @@ public class BufferSerializer implements Serializer<Buffer> {
 
   @Override
   public byte[] serialize(String topic, Buffer data) {
+    if (data == null)
+      return null;
+
     return data.getBytes();
   }
 


### PR DESCRIPTION
Most Kafka Serializers handle passed in null values, like said here: https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/serialization/Deserializer.java#L39

This PR contains a quick fix for both, and adds a very simple unit test