### PR TITLE
Update to Kafka 0.10.1.1. Adds beginningOffsets, endOffsets, offsetsForTimes methods to Kafka Client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,8 @@
 
   <properties>
     <stack.version>3.4.1-SNAPSHOT</stack.version>
+    <kafka.version>0.10.1.1</kafka.version>
+    <debezium.version>0.4.0</debezium.version>
   </properties>
 
   <dependencyManagement>
@@ -68,7 +70,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>0.10.0.1</version>
+      <version>${kafka.version}</version>
     </dependency>
     <dependency>
       <!-- Kafka requires SLF4J: declare this dependency to force shiro to use this one. It is the version used by vert.x -->
@@ -105,7 +107,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.11</artifactId>
-      <version>0.10.0.1</version>
+      <version>${kafka.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -123,13 +125,13 @@
     <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-core</artifactId>
-      <version>0.3.1</version>
+      <version>${debezium.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-core</artifactId>
-      <version>0.3.1</version>
+      <version>${debezium.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -68,6 +68,28 @@ Set the offset to commit
 +++
 |===
 
+[[OffsetAndTimestamp]]
+== OffsetAndTimestamp
+
+++++
+ Represent information related to a Offset with timestamp information
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[offset]]`offset`|`Number (long)`|
++++
+Set the offset
++++
+|[[timestamp]]`timestamp`|`Number (long)`|
++++
+Set the timestamp
++++
+|===
+
 [[PartitionInfo]]
 == PartitionInfo
 

--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -25,7 +25,7 @@ of your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-kafka-client</artifactId>
-  <version>3.4.0</version>
+  <version>3.4.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -33,7 +33,7 @@ of your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-kafka-client:3.4.0
+compile io.vertx:vertx-kafka-client:3.4.1-SNAPSHOT
 ----
 
 == Creating Kafka clients
@@ -388,7 +388,7 @@ consumer.commit({ ar ->
 == Seeking in a topic partition
 
 Apache Kafka can retain messages for a long period of time and the consumer can seek inside a topic partition
-and obtain arbitraty access to the messages.
+and obtain arbitrary access to the messages.
 
 You can use `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#seek-io.vertx.kafka.client.common.TopicPartition-long-[seek]` to change the offset for reading at a specific
 position
@@ -452,6 +452,81 @@ consumer.seekToEnd(java.util.Collections.singleton(topicPartition), { done ->
 
 ----
 
+== Offset lookup
+
+You can use the beginningOffsets API introduced in Kafka 0.10.1.1 to get the first offset
+for a given partition. In contrast to `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#seekToBeginning-io.vertx.kafka.client.common.TopicPartition-[seekToBeginning]`,
+it does not change the consumer's offset.
+
+[source,groovy]
+----
+def topicPartitions = new java.util.HashSet()
+def topicPartition = [
+  topic:"test",
+  partition:0
+]
+topicPartitions.add(topicPartition)
+
+consumer.beginningOffsets(topicPartitions, { done ->
+  if (done.succeeded()) {
+    def results = done.result()
+    results.each { topic, beginningOffset ->
+      println("Beginning offset for topic=${topic.topic}, partition=${topic.partition}, beginningOffset=${beginningOffset}")
+    }
+  }
+})
+
+// Convenience method for single-partition lookup
+consumer.beginningOffsets(topicPartition, { done ->
+  if (done.succeeded()) {
+    def beginningOffset = done.result()
+    println("Beginning offset for topic=${topicPartition.topic}, partition=${topicPartition.partition}, beginningOffset=${beginningOffset}")
+  }
+})
+
+
+----
+
+You can use the endOffsets API introduced in Kafka 0.10.1.1 to get the last offset
+for a given partition. In contrast to `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#seekToEnd-io.vertx.kafka.client.common.TopicPartition-[seekToEnd]`,
+it does not change the consumer's offset.
+
+[source,groovy]
+----
+def topicPartitions = new java.util.HashSet()
+def topicPartition = [
+  topic:"test",
+  partition:0
+]
+topicPartitions.add(topicPartition)
+
+consumer.endOffsets(topicPartitions, { done ->
+  if (done.succeeded()) {
+    def results = done.result()
+    results.each { topic, endOffset ->
+      println("End offset for topic=${topic.topic}, partition=${topic.partition}, endOffset=${endOffset}")
+    }
+  }
+})
+
+// Convenience method for single-partition lookup
+consumer.endOffsets(topicPartition, { done ->
+  if (done.succeeded()) {
+    def endOffset = done.result()
+    println("End offset for topic=${topicPartition.topic}, partition=${topicPartition.partition}, endOffset=${endOffset}")
+  }
+})
+
+----
+
+You can use the offsetsForTimes API introduced in Kafka 0.10.1.1 to look up an offset by
+timestamp, i.e. search parameter is an epoch timestamp and the call returns the lowest offset
+with ingestion timestamp >= given timestamp.
+
+[source,groovy]
+----
+Code not translatable
+----
 == Message flow control
 
 A consumer can control the incoming message flow and pause/resume the read operation from a topic, e.g it

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -25,7 +25,7 @@ of your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-kafka-client</artifactId>
-  <version>3.4.0</version>
+  <version>3.4.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -33,7 +33,7 @@ of your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-kafka-client:3.4.0
+compile io.vertx:vertx-kafka-client:3.4.1-SNAPSHOT
 ----
 
 == Creating Kafka clients
@@ -346,7 +346,7 @@ consumer.commit(ar -> {
 == Seeking in a topic partition
 
 Apache Kafka can retain messages for a long period of time and the consumer can seek inside a topic partition
-and obtain arbitraty access to the messages.
+and obtain arbitrary access to the messages.
 
 You can use `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#seek-io.vertx.kafka.client.common.TopicPartition-long-[seek]` to change the offset for reading at a specific
 position
@@ -400,6 +400,91 @@ consumer.seekToEnd(Collections.singleton(topicPartition), done -> {
 });
 ----
 
+== Offset lookup
+
+You can use the beginningOffsets API introduced in Kafka 0.10.1.1 to get the first offset
+for a given partition. In contrast to `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#seekToBeginning-io.vertx.kafka.client.common.TopicPartition-[seekToBeginning]`,
+it does not change the consumer's offset.
+
+[source,java]
+----
+Set<TopicPartition> topicPartitions = new HashSet<>();
+TopicPartition topicPartition = new TopicPartition().setTopic("test").setPartition(0);
+topicPartitions.add(topicPartition);
+
+consumer.beginningOffsets(topicPartitions, done -> {
+  if(done.succeeded()) {
+    Map<TopicPartition, Long> results = done.result();
+    results.forEach((topic, beginningOffset) ->
+      System.out.println("Beginning offset for topic="+topic.getTopic()+", partition="+
+        topic.getPartition()+", beginningOffset="+beginningOffset));
+  }
+});
+
+// Convenience method for single-partition lookup
+consumer.beginningOffsets(topicPartition, done -> {
+  if(done.succeeded()) {
+    Long beginningOffset = done.result();
+      System.out.println("Beginning offset for topic="+topicPartition.getTopic()+", partition="+
+        topicPartition.getPartition()+", beginningOffset="+beginningOffset);
+  }
+});
+----
+
+You can use the endOffsets API introduced in Kafka 0.10.1.1 to get the last offset
+for a given partition. In contrast to `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#seekToEnd-io.vertx.kafka.client.common.TopicPartition-[seekToEnd]`,
+it does not change the consumer's offset.
+
+[source,java]
+----
+Set<TopicPartition> topicPartitions = new HashSet<>();
+TopicPartition topicPartition = new TopicPartition().setTopic("test").setPartition(0);
+topicPartitions.add(topicPartition);
+
+consumer.endOffsets(topicPartitions, done -> {
+  if(done.succeeded()) {
+    Map<TopicPartition, Long> results = done.result();
+    results.forEach((topic, endOffset) ->
+      System.out.println("End offset for topic="+topic.getTopic()+", partition="+
+        topic.getPartition()+", endOffset="+endOffset));
+  }
+});
+
+// Convenience method for single-partition lookup
+consumer.endOffsets(topicPartition, done -> {
+  if(done.succeeded()) {
+    Long endOffset = done.result();
+      System.out.println("End offset for topic="+topicPartition.getTopic()+", partition="+
+        topicPartition.getPartition()+", endOffset="+endOffset);
+  }
+});
+----
+
+You can use the offsetsForTimes API introduced in Kafka 0.10.1.1 to look up an offset by
+timestamp, i.e. search parameter is an epoch timestamp and the call returns the lowest offset
+with ingestion timestamp >= given timestamp.
+
+[source,java]
+----
+Map<TopicPartition, Long> topicPartitionsWithTimestamps = new HashMap<>();
+TopicPartition topicPartition = new TopicPartition()
+  .setTopic("test")
+  .setPartition(0);
+
+// We are interested in the offset for data ingested 60 seconds ago
+long timestamp = (System.currentTimeMillis() - 60000);
+
+topicPartitionsWithTimestamps.put(topicPartition, timestamp);
+consumer.offsetsForTimes(topicPartitionsWithTimestamps, done -> {
+  if(done.succeeded()) {
+    Map<TopicPartition, OffsetAndTimestamp> results = done.result();
+    results.forEach((topic, offset) ->
+      System.out.println("Offset for topic="+topic.getTopic()+", partition="+topic.getPartition()+"\n"+
+        ", timestamp="+timestamp+", offset="+offset.getOffset()+", offsetTimestamp="+offset.getTimestamp()));
+
+  }
+});
+----
 == Message flow control
 
 A consumer can control the incoming message flow and pause/resume the read operation from a topic, e.g it

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -25,7 +25,7 @@ of your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-kafka-client</artifactId>
-  <version>3.4.0</version>
+  <version>3.4.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -33,7 +33,7 @@ of your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-kafka-client:3.4.0
+compile io.vertx:vertx-kafka-client:3.4.1-SNAPSHOT
 ----
 
 == Creating Kafka clients
@@ -392,7 +392,7 @@ consumer.commit(function (ar, ar_err) {
 == Seeking in a topic partition
 
 Apache Kafka can retain messages for a long period of time and the consumer can seek inside a topic partition
-and obtain arbitraty access to the messages.
+and obtain arbitrary access to the messages.
 
 You can use `link:../../jsdoc/module-vertx-kafka-client-js_kafka_consumer-KafkaConsumer.html#seek[seek]` to change the offset for reading at a specific
 position
@@ -456,6 +456,81 @@ consumer.seekToEnd(Java.type("java.util.Collections").singleton(topicPartition),
 
 ----
 
+== Offset lookup
+
+You can use the beginningOffsets API introduced in Kafka 0.10.1.1 to get the first offset
+for a given partition. In contrast to `link:../../jsdoc/module-vertx-kafka-client-js_kafka_consumer-KafkaConsumer.html#seekToBeginning[seekToBeginning]`,
+it does not change the consumer's offset.
+
+[source,js]
+----
+var topicPartitions = new (Java.type("java.util.HashSet"))();
+var topicPartition = {
+  "topic" : "test",
+  "partition" : 0
+};
+topicPartitions.add(topicPartition);
+
+consumer.beginningOffsets(topicPartitions, function (done, done_err) {
+  if (done_err == null) {
+    var results = done;
+    results.forEach(function (beginningOffset, topic) {
+      console.log("Beginning offset for topic=" + topic.topic + ", partition=" + topic.partition + ", beginningOffset=" + beginningOffset);
+    });
+  }
+});
+
+// Convenience method for single-partition lookup
+consumer.beginningOffsets(topicPartition, function (done, done_err) {
+  if (done_err == null) {
+    var beginningOffset = done;
+    console.log("Beginning offset for topic=" + topicPartition.topic + ", partition=" + topicPartition.partition + ", beginningOffset=" + beginningOffset);
+  }
+});
+
+
+----
+
+You can use the endOffsets API introduced in Kafka 0.10.1.1 to get the last offset
+for a given partition. In contrast to `link:../../jsdoc/module-vertx-kafka-client-js_kafka_consumer-KafkaConsumer.html#seekToEnd[seekToEnd]`,
+it does not change the consumer's offset.
+
+[source,js]
+----
+var topicPartitions = new (Java.type("java.util.HashSet"))();
+var topicPartition = {
+  "topic" : "test",
+  "partition" : 0
+};
+topicPartitions.add(topicPartition);
+
+consumer.endOffsets(topicPartitions, function (done, done_err) {
+  if (done_err == null) {
+    var results = done;
+    results.forEach(function (endOffset, topic) {
+      console.log("End offset for topic=" + topic.topic + ", partition=" + topic.partition + ", endOffset=" + endOffset);
+    });
+  }
+});
+
+// Convenience method for single-partition lookup
+consumer.endOffsets(topicPartition, function (done, done_err) {
+  if (done_err == null) {
+    var endOffset = done;
+    console.log("End offset for topic=" + topicPartition.topic + ", partition=" + topicPartition.partition + ", endOffset=" + endOffset);
+  }
+});
+
+----
+
+You can use the offsetsForTimes API introduced in Kafka 0.10.1.1 to look up an offset by
+timestamp, i.e. search parameter is an epoch timestamp and the call returns the lowest offset
+with ingestion timestamp >= given timestamp.
+
+[source,js]
+----
+Code not translatable
+----
 == Message flow control
 
 A consumer can control the incoming message flow and pause/resume the read operation from a topic, e.g it

--- a/src/main/asciidoc/kotlin/index.adoc
+++ b/src/main/asciidoc/kotlin/index.adoc
@@ -25,7 +25,7 @@ of your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-kafka-client</artifactId>
-  <version>3.4.0</version>
+  <version>3.4.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -33,7 +33,7 @@ of your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-kafka-client:3.4.0
+compile io.vertx:vertx-kafka-client:3.4.1-SNAPSHOT
 ----
 
 == Creating Kafka clients
@@ -388,7 +388,7 @@ consumer.commit({ ar ->
 == Seeking in a topic partition
 
 Apache Kafka can retain messages for a long period of time and the consumer can seek inside a topic partition
-and obtain arbitraty access to the messages.
+and obtain arbitrary access to the messages.
 
 You can use `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#seek-io.vertx.kafka.client.common.TopicPartition-long-[seek]` to change the offset for reading at a specific
 position
@@ -449,6 +449,81 @@ consumer.seekToEnd(java.util.Collections.singleton(topicPartition), { done ->
 
 ----
 
+== Offset lookup
+
+You can use the beginningOffsets API introduced in Kafka 0.10.1.1 to get the first offset
+for a given partition. In contrast to `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#seekToBeginning-io.vertx.kafka.client.common.TopicPartition-[seekToBeginning]`,
+it does not change the consumer's offset.
+
+[source,kotlin]
+----
+var topicPartitions = java.util.HashSet()
+var topicPartition = TopicPartition(
+  topic = "test",
+  partition = 0)
+topicPartitions.add(topicPartition)
+
+consumer.beginningOffsets(topicPartitions, { done ->
+  if (done.succeeded()) {
+    var results = done.result()
+    for ((topic, beginningOffset) in results) {
+      println("Beginning offset for topic=${topic.topic}, partition=${topic.partition}, beginningOffset=${beginningOffset}")
+    }
+
+  }
+})
+
+// Convenience method for single-partition lookup
+consumer.beginningOffsets(topicPartition, { done ->
+  if (done.succeeded()) {
+    var beginningOffset = done.result()
+    println("Beginning offset for topic=${topicPartition.topic}, partition=${topicPartition.partition}, beginningOffset=${beginningOffset}")
+  }
+})
+
+
+----
+
+You can use the endOffsets API introduced in Kafka 0.10.1.1 to get the last offset
+for a given partition. In contrast to `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#seekToEnd-io.vertx.kafka.client.common.TopicPartition-[seekToEnd]`,
+it does not change the consumer's offset.
+
+[source,kotlin]
+----
+var topicPartitions = java.util.HashSet()
+var topicPartition = TopicPartition(
+  topic = "test",
+  partition = 0)
+topicPartitions.add(topicPartition)
+
+consumer.endOffsets(topicPartitions, { done ->
+  if (done.succeeded()) {
+    var results = done.result()
+    for ((topic, endOffset) in results) {
+      println("End offset for topic=${topic.topic}, partition=${topic.partition}, endOffset=${endOffset}")
+    }
+
+  }
+})
+
+// Convenience method for single-partition lookup
+consumer.endOffsets(topicPartition, { done ->
+  if (done.succeeded()) {
+    var endOffset = done.result()
+    println("End offset for topic=${topicPartition.topic}, partition=${topicPartition.partition}, endOffset=${endOffset}")
+  }
+})
+
+----
+
+You can use the offsetsForTimes API introduced in Kafka 0.10.1.1 to look up an offset by
+timestamp, i.e. search parameter is an epoch timestamp and the call returns the lowest offset
+with ingestion timestamp >= given timestamp.
+
+[source,kotlin]
+----
+Code not translatable
+----
 == Message flow control
 
 A consumer can control the incoming message flow and pause/resume the read operation from a topic, e.g it

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -25,7 +25,7 @@ of your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-kafka-client</artifactId>
-  <version>3.4.0</version>
+  <version>3.4.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -33,7 +33,7 @@ of your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-kafka-client:3.4.0
+compile io.vertx:vertx-kafka-client:3.4.1-SNAPSHOT
 ----
 
 == Creating Kafka clients
@@ -392,7 +392,7 @@ consumer.commit() { |ar_err,ar|
 == Seeking in a topic partition
 
 Apache Kafka can retain messages for a long period of time and the consumer can seek inside a topic partition
-and obtain arbitraty access to the messages.
+and obtain arbitrary access to the messages.
 
 You can use `link:../../yardoc/VertxKafkaClient/KafkaConsumer.html#seek-instance_method[seek]` to change the offset for reading at a specific
 position
@@ -456,6 +456,81 @@ consumer.seek_to_end(Java::JavaUtil::Collections.singleton(topicPartition)) { |d
 
 ----
 
+== Offset lookup
+
+You can use the beginningOffsets API introduced in Kafka 0.10.1.1 to get the first offset
+for a given partition. In contrast to `link:../../yardoc/VertxKafkaClient/KafkaConsumer.html#seek_to_beginning-instance_method[seekToBeginning]`,
+it does not change the consumer's offset.
+
+[source,ruby]
+----
+topicPartitions = Java::JavaUtil::HashSet.new()
+topicPartition = {
+  'topic' => "test",
+  'partition' => 0
+}
+topicPartitions.add?(topicPartition)
+
+consumer.beginning_offsets(topicPartitions) { |done_err,done|
+  if (done_err == nil)
+    results = done
+    results.each_pair { |topic,beginningOffset|
+      puts "Beginning offset for topic=#{topic['topic']}, partition=#{topic['partition']}, beginningOffset=#{beginningOffset}"
+    }
+  end
+}
+
+# Convenience method for single-partition lookup
+consumer.beginning_offsets(topicPartition) { |done_err,done|
+  if (done_err == nil)
+    beginningOffset = done
+    puts "Beginning offset for topic=#{topicPartition['topic']}, partition=#{topicPartition['partition']}, beginningOffset=#{beginningOffset}"
+  end
+}
+
+
+----
+
+You can use the endOffsets API introduced in Kafka 0.10.1.1 to get the last offset
+for a given partition. In contrast to `link:../../yardoc/VertxKafkaClient/KafkaConsumer.html#seek_to_end-instance_method[seekToEnd]`,
+it does not change the consumer's offset.
+
+[source,ruby]
+----
+topicPartitions = Java::JavaUtil::HashSet.new()
+topicPartition = {
+  'topic' => "test",
+  'partition' => 0
+}
+topicPartitions.add?(topicPartition)
+
+consumer.end_offsets(topicPartitions) { |done_err,done|
+  if (done_err == nil)
+    results = done
+    results.each_pair { |topic,endOffset|
+      puts "End offset for topic=#{topic['topic']}, partition=#{topic['partition']}, endOffset=#{endOffset}"
+    }
+  end
+}
+
+# Convenience method for single-partition lookup
+consumer.end_offsets(topicPartition) { |done_err,done|
+  if (done_err == nil)
+    endOffset = done
+    puts "End offset for topic=#{topicPartition['topic']}, partition=#{topicPartition['partition']}, endOffset=#{endOffset}"
+  end
+}
+
+----
+
+You can use the offsetsForTimes API introduced in Kafka 0.10.1.1 to look up an offset by
+timestamp, i.e. search parameter is an epoch timestamp and the call returns the lowest offset
+with ingestion timestamp >= given timestamp.
+
+[source,ruby]
+----
+Code not translatable
+----
 == Message flow control
 
 A consumer can control the incoming message flow and pause/resume the read operation from a topic, e.g it

--- a/src/main/java/examples/VertxKafkaClientExamples.java
+++ b/src/main/java/examples/VertxKafkaClientExamples.java
@@ -475,7 +475,7 @@ public class VertxKafkaClientExamples {
           System.out.println("Offset for topic="+topicPartition.getTopic()+
             ", partition="+topicPartition.getPartition()+"\n"+
             ", timestamp="+timestamp+", offset="+offsetAndTimestamp.getOffset()+
-            ", offsetTimestamp="+offsetAndTimestamp.getTimestamp()));
+            ", offsetTimestamp="+offsetAndTimestamp.getTimestamp());
 
       }
     });

--- a/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
+++ b/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
@@ -18,6 +18,7 @@ package io.vertx.kafka.client.common.impl;
 
 import io.vertx.core.Handler;
 import io.vertx.kafka.client.common.Node;
+import io.vertx.kafka.client.consumer.OffsetAndTimestamp;
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.OffsetAndMetadata;
 import io.vertx.kafka.client.producer.RecordMetadata;
@@ -98,5 +99,33 @@ public class Helper {
 
   public static org.apache.kafka.clients.consumer.OffsetAndMetadata to(OffsetAndMetadata offsetAndMetadata) {
     return new org.apache.kafka.clients.consumer.OffsetAndMetadata(offsetAndMetadata.getOffset(), offsetAndMetadata.getMetadata());
+  }
+
+  public static Map<TopicPartition, Long> fromTopicPartitionOffsets(Map<org.apache.kafka.common.TopicPartition, Long> offsets) {
+    return offsets.entrySet().stream().collect(Collectors.toMap(
+      e -> new TopicPartition(e.getKey().topic(), e.getKey().partition()),
+      Map.Entry::getValue)
+    );
+  }
+
+  public static Map<org.apache.kafka.common.TopicPartition, Long> toTopicPartitionTimes(Map<TopicPartition, Long> topicPartitionTimes) {
+    return topicPartitionTimes.entrySet().stream().collect(Collectors.toMap(
+      e -> new org.apache.kafka.common.TopicPartition(e.getKey().getTopic(), e.getKey().getPartition()),
+      Map.Entry::getValue)
+    );
+  }
+
+  public static Map<org.apache.kafka.common.TopicPartition, org.apache.kafka.clients.consumer.OffsetAndTimestamp> toTopicPartitionOffsetAndTimestamp(Map<TopicPartition, OffsetAndTimestamp> topicPartitionOffsetAndTimestamps) {
+    return topicPartitionOffsetAndTimestamps.entrySet().stream().collect(Collectors.toMap(
+      e -> new org.apache.kafka.common.TopicPartition(e.getKey().getTopic(), e.getKey().getPartition()),
+      e -> new org.apache.kafka.clients.consumer.OffsetAndTimestamp(e.getValue().getOffset(), e.getValue().getTimestamp()))
+    );
+  }
+
+  public static Map<TopicPartition, OffsetAndTimestamp> fromTopicPartitionOffsetAndTimestamp(Map<org.apache.kafka.common.TopicPartition, org.apache.kafka.clients.consumer.OffsetAndTimestamp> topicPartitionOffsetAndTimestamps) {
+    return topicPartitionOffsetAndTimestamps.entrySet().stream().collect(Collectors.toMap(
+      e -> new TopicPartition(e.getKey().topic(), e.getKey().partition()),
+      e -> new OffsetAndTimestamp(e.getValue().offset(), e.getValue().timestamp()))
+    );
   }
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
@@ -26,7 +26,6 @@ import io.vertx.core.streams.ReadStream;
 import io.vertx.kafka.client.common.PartitionInfo;
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.impl.KafkaConsumerImpl;
-import io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl;
 import org.apache.kafka.clients.consumer.Consumer;
 
 import java.util.HashMap;
@@ -525,6 +524,54 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
    * @param handler handler called on operation completed
    */
   void position(TopicPartition partition, Handler<AsyncResult<Long>> handler);
+
+  /**
+   * Look up the offsets for the given partitions by timestamp.
+   * @param topicPartitionTimestamps A map with pairs of (TopicPartition, Timestamp).
+   * @param handler handler called on operation completed
+   */
+  @GenIgnore
+  void offsetsForTimes(Map<TopicPartition, Long> topicPartitionTimestamps, Handler<AsyncResult<Map<TopicPartition, OffsetAndTimestamp>>> handler);
+
+  /**
+   * Look up the offset for the given partition by timestamp.
+   * @param topicPartition TopicPartition to query.
+   * @param timestamp Timestamp to be used in the query.
+   * @param handler handler called on operation completed
+   */
+  void offsetsForTimes(TopicPartition topicPartition, Long timestamp, Handler<AsyncResult<OffsetAndTimestamp>> handler);
+
+  /**
+   * Get the first offset for the given partitions.
+   * @param topicPartitions the partitions to get the earliest offsets.
+   * @param handler handler called on operation completed. Returns the earliest available offsets for the given partitions
+   */
+  @GenIgnore
+  void beginningOffsets(Set<TopicPartition> topicPartitions, Handler<AsyncResult<Map<TopicPartition, Long>>> handler);
+
+  /**
+   * Get the first offset for the given partitions.
+   * @param topicPartition the partition to get the earliest offset.
+   * @param handler handler called on operation completed. Returns the earliest available offset for the given partition
+   */
+  void beginningOffsets(TopicPartition topicPartition, Handler<AsyncResult<Long>> handler);
+
+  /**
+   * Get the last offset for the given partitions. The last offset of a partition is the offset
+   * of the upcoming message, i.e. the offset of the last available message + 1.
+   * @param topicPartitions the partitions to get the end offsets.
+   * @param handler handler called on operation completed. The end offsets for the given partitions.
+   */
+  @GenIgnore
+  void endOffsets(Set<TopicPartition> topicPartitions, Handler<AsyncResult<Map<TopicPartition, Long>>> handler);
+
+  /**
+   * Get the last offset for the given partition. The last offset of a partition is the offset
+   * of the upcoming message, i.e. the offset of the last available message + 1.
+   * @param topicPartition the partition to get the end offset.
+   * @param handler handler called on operation completed. The end offset for the given partition.
+   */
+  void endOffsets(TopicPartition topicPartition, Handler<AsyncResult<Long>> handler);
 
   /**
    * @return  underlying the {@link KafkaReadStream} instance

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
@@ -25,6 +25,7 @@ import io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -356,6 +357,52 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
    * @param handler handler called on operation completed
    */
   void position(TopicPartition partition, Handler<AsyncResult<Long>> handler);
+
+  /**
+   * Look up the offsets for the given partitions by timestamp.
+   * @param topicPartitionTimestamps A map with pairs of (TopicPartition, Timestamp).
+   * @param handler handler called on operation completed
+   */
+  void offsetsForTimes(Map<TopicPartition, Long> topicPartitionTimestamps, Handler<AsyncResult<Map<TopicPartition, OffsetAndTimestamp>>> handler);
+
+  /**
+   * * Look up the offset for the given partition by timestamp.
+   * @param topicPartition Partition to query.
+   * @param timestamp Timestamp used to determine the offset.
+   * @param handler handler called on operation completed
+   */
+  void offsetsForTimes(TopicPartition topicPartition, long timestamp, Handler<AsyncResult<OffsetAndTimestamp>> handler);
+
+  /**
+   * Get the first offset for the given partitions.
+   * @param topicPartitions the partitions to get the earliest offsets.
+   * @param handler handler called on operation completed. Returns the earliest available offsets for the given partitions
+   */
+  void beginningOffsets(Set<TopicPartition> topicPartitions, Handler<AsyncResult<Map<TopicPartition, Long>>> handler);
+
+  /**
+   * Get the first offset for the given partition.
+   * @param topicPartition the partition to get the earliest offset.
+   * @param handler handler called on operation completed. Returns the earliest available offset for the given partition
+   */
+  void beginningOffsets(TopicPartition topicPartition, Handler<AsyncResult<Long>> handler);
+
+  /**
+   * Get the last offset for the given partitions. The last offset of a partition is the offset
+   * of the upcoming message, i.e. the offset of the last available message + 1.
+   * @param topicPartitions the partitions to get the end offsets.
+   * @param handler handler called on operation completed. The end offsets for the given partitions.
+   */
+  void endOffsets(Set<TopicPartition> topicPartitions, Handler<AsyncResult<Map<TopicPartition, Long>>> handler);
+
+  /**
+   * Get the last offset for the given partition. The last offset of a partition is the offset
+   * of the upcoming message, i.e. the offset of the last available message + 1.
+   * @param topicPartition the partition to get the end offset.
+   * @param handler handler called on operation completed. The end offset for the given partition.
+   */
+  void endOffsets(TopicPartition topicPartition, Handler<AsyncResult<Long>> handler);
+
 
   /**
    * @return the native consumer

--- a/src/main/java/io/vertx/kafka/client/consumer/OffsetAndTimestamp.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/OffsetAndTimestamp.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2016 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.kafka.client.consumer;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Represent information related to a Offset with timestamp information
+ */
+@DataObject
+public class OffsetAndTimestamp {
+
+  private long offset;
+  private long timestamp;
+
+  /**
+   * Constructor
+   */
+  public OffsetAndTimestamp() {
+  }
+
+  /**
+   * Constructor
+   *
+   * @param offset the offset
+   * @param timestamp the timestamp
+   */
+  public OffsetAndTimestamp(long offset, long timestamp) {
+    this.offset = offset;
+    this.timestamp = timestamp;
+  }
+
+  /**
+   * Constructor (from JSON representation)
+   *
+   * @param json  JSON representation
+   */
+  public OffsetAndTimestamp(JsonObject json) {
+    this.offset = json.getLong("offset");
+    this.timestamp = json.getLong("timestamp");
+  }
+
+  /**
+   * Constructor (copy)
+   *
+   * @param that  object to copy
+   */
+  public OffsetAndTimestamp(OffsetAndTimestamp that) {
+      this.offset = that.offset;
+      this.timestamp = that.timestamp;
+  }
+
+  /**
+   * @return  the offset
+   */
+  public long getOffset() {
+    return this.offset;
+  }
+
+  /**
+   * Set the offset
+   *
+   * @param offset the offset
+   * @return current instance of the class to be fluent
+   */
+  public OffsetAndTimestamp setOffset(long offset) {
+    this.offset = offset;
+    return this;
+  }
+
+  /**
+   * @return  the timestamp
+   */
+  public long getTimestamp() {
+    return this.timestamp;
+  }
+
+  /**
+   * Set the timestamp
+   *
+   * @param timestamp the timestamp
+   * @return  current instance of the class to be fluent
+   */
+  public OffsetAndTimestamp setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+    return this;
+  }
+
+  /**
+   * Convert object to JSON representation
+   *
+   * @return  JSON representation
+   */
+  public JsonObject toJson() {
+    return new JsonObject().put("offset", this.offset).put("timestamp", this.timestamp);
+  }
+
+  @Override
+  public String toString() {
+
+    return "OffsetAndTimestamp{" +
+      "offset=" + this.offset +
+      ", timestamp=" + this.timestamp +
+      "}";
+  }
+}

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
@@ -416,15 +416,15 @@ public class KafkaConsumerImpl<K, V> implements KafkaConsumer<K, V> {
 
   @Override
   public void offsetsForTimes(TopicPartition topicPartition, Long timestamp, Handler<AsyncResult<OffsetAndTimestamp>> handler) {
-    Map<TopicPartition, Long> input = new HashMap<>();
-    input.put(topicPartition, timestamp);
+    Map<TopicPartition, Long> topicPartitions = new HashMap<>();
+    topicPartitions.put(topicPartition, timestamp);
 
-    this.stream.offsetsForTimes(Helper.toTopicPartitionTimes(input), done -> {
+    this.stream.offsetsForTimes(Helper.toTopicPartitionTimes(topicPartitions), done -> {
       if(done.succeeded()) {
         // We know that this will result in exactly one iteration
         for(org.apache.kafka.clients.consumer.OffsetAndTimestamp offsetAndTimestamp : done.result().values()) {
-          OffsetAndTimestamp r = new OffsetAndTimestamp(offsetAndTimestamp.offset(), offsetAndTimestamp.timestamp());
-          handler.handle(Future.succeededFuture(r));
+          OffsetAndTimestamp resultOffsetAndTimestamp = new OffsetAndTimestamp(offsetAndTimestamp.offset(), offsetAndTimestamp.timestamp());
+          handler.handle(Future.succeededFuture(resultOffsetAndTimestamp));
           break;
         }
       } else {
@@ -457,13 +457,13 @@ public class KafkaConsumerImpl<K, V> implements KafkaConsumer<K, V> {
 
   @Override
   public void beginningOffsets(TopicPartition topicPartition, Handler<AsyncResult<Long>> handler) {
-    Set<TopicPartition> input = new HashSet<>();
-    input.add(topicPartition);
-    this.stream.beginningOffsets(Helper.to(input), done -> {
+    Set<TopicPartition> beginningOffsets = new HashSet<>();
+    beginningOffsets.add(topicPartition);
+    this.stream.beginningOffsets(Helper.to(beginningOffsets), done -> {
       if(done.succeeded()) {
         // We know that this will result in exactly one iteration
-        for(long value : done.result().values()) {
-          handler.handle(Future.succeededFuture(value));
+        for(long beginningOffset : done.result().values()) {
+          handler.handle(Future.succeededFuture(beginningOffset));
           break;
         }
       } else {
@@ -489,8 +489,8 @@ public class KafkaConsumerImpl<K, V> implements KafkaConsumer<K, V> {
     topicPartitions.add(topicPartition);
     this.stream.endOffsets(Helper.to(topicPartitions), done -> {
       if(done.succeeded()) {
-        for(long value : done.result().values()) {
-          handler.handle(Future.succeededFuture(value));
+        for(long endOffset : done.result().values()) {
+          handler.handle(Future.succeededFuture(endOffset));
           break;
         }
       } else {

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
@@ -17,11 +17,11 @@
 package io.vertx.kafka.client.consumer.impl;
 
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Closeable;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.kafka.client.consumer.OffsetAndTimestamp;
 import io.vertx.kafka.client.common.impl.CloseHandler;
 import io.vertx.kafka.client.common.impl.Helper;
 import io.vertx.kafka.client.common.PartitionInfo;
@@ -35,6 +35,7 @@ import org.apache.kafka.clients.consumer.Consumer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -411,6 +412,91 @@ public class KafkaConsumerImpl<K, V> implements KafkaConsumer<K, V> {
   @Override
   public void position(TopicPartition partition, Handler<AsyncResult<Long>> handler) {
     this.stream.position(Helper.to(partition), handler);
+  }
+
+  @Override
+  public void offsetsForTimes(TopicPartition topicPartition, Long timestamp, Handler<AsyncResult<OffsetAndTimestamp>> handler) {
+    Map<TopicPartition, Long> input = new HashMap<>();
+    input.put(topicPartition, timestamp);
+
+    this.stream.offsetsForTimes(Helper.toTopicPartitionTimes(input), done -> {
+      if(done.succeeded()) {
+        // We know that this will result in exactly one iteration
+        for(org.apache.kafka.clients.consumer.OffsetAndTimestamp offsetAndTimestamp : done.result().values()) {
+          OffsetAndTimestamp r = new OffsetAndTimestamp(offsetAndTimestamp.offset(), offsetAndTimestamp.timestamp());
+          handler.handle(Future.succeededFuture(r));
+          break;
+        }
+      } else {
+        handler.handle(Future.failedFuture(done.cause()));
+      }
+    });
+  }
+
+  @Override
+  public void offsetsForTimes(Map<TopicPartition, Long> topicPartitionTimestamps, Handler<AsyncResult<Map<TopicPartition, OffsetAndTimestamp>>> handler) {
+    this.stream.offsetsForTimes(Helper.toTopicPartitionTimes(topicPartitionTimestamps), done -> {
+      if(done.succeeded()) {
+        handler.handle(Future.succeededFuture(Helper.fromTopicPartitionOffsetAndTimestamp(done.result())));
+      } else {
+        handler.handle(Future.failedFuture(done.cause()));
+      }
+    });
+  }
+
+  @Override
+  public void beginningOffsets(Set<TopicPartition> topicPartitions, Handler<AsyncResult<Map<TopicPartition, Long>>> handler) {
+    this.stream.beginningOffsets(Helper.to(topicPartitions), done -> {
+      if(done.succeeded()) {
+        handler.handle(Future.succeededFuture(Helper.fromTopicPartitionOffsets(done.result())));
+      } else {
+        handler.handle(Future.failedFuture(done.cause()));
+      }
+    });
+  }
+
+  @Override
+  public void beginningOffsets(TopicPartition topicPartition, Handler<AsyncResult<Long>> handler) {
+    Set<TopicPartition> input = new HashSet<>();
+    input.add(topicPartition);
+    this.stream.beginningOffsets(Helper.to(input), done -> {
+      if(done.succeeded()) {
+        // We know that this will result in exactly one iteration
+        for(long value : done.result().values()) {
+          handler.handle(Future.succeededFuture(value));
+          break;
+        }
+      } else {
+        handler.handle(Future.failedFuture(done.cause()));
+      }
+    });
+  }
+
+  @Override
+  public void endOffsets(Set<TopicPartition> topicPartitions, Handler<AsyncResult<Map<TopicPartition, Long>>> handler) {
+    this.stream.endOffsets(Helper.to(topicPartitions), done -> {
+      if(done.succeeded()) {
+        handler.handle(Future.succeededFuture(Helper.fromTopicPartitionOffsets(done.result())));
+      } else {
+        handler.handle(Future.failedFuture(done.cause()));
+      }
+    });
+  }
+
+  @Override
+  public void endOffsets(TopicPartition topicPartition, Handler<AsyncResult<Long>> handler) {
+    Set<TopicPartition> topicPartitions = new HashSet<>();
+    topicPartitions.add(topicPartition);
+    this.stream.endOffsets(Helper.to(topicPartitions), done -> {
+      if(done.succeeded()) {
+        for(long value : done.result().values()) {
+          handler.handle(Future.succeededFuture(value));
+          break;
+        }
+      } else {
+        handler.handle(Future.failedFuture(done.cause()));
+      }
+    });
   }
 
   @Override

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
@@ -27,12 +27,15 @@ import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -529,6 +532,74 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
       long pos = this.consumer.position(partition);
       if (future != null) {
         future.complete(pos);
+      }
+    }, handler);
+  }
+
+  @Override
+  public void offsetsForTimes(Map<TopicPartition, Long> topicPartitionTimestamps, Handler<AsyncResult<Map<TopicPartition, OffsetAndTimestamp>>> handler) {
+    this.submitTask((consumer, future) -> {
+      Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes = this.consumer.offsetsForTimes(topicPartitionTimestamps);
+      if (future != null) {
+        future.complete(offsetsForTimes);
+      }
+    }, handler);
+  }
+
+  @Override
+  public void offsetsForTimes(TopicPartition topicPartition, long timestamp, Handler<AsyncResult<OffsetAndTimestamp>> handler) {
+    this.submitTask((consumer, future) -> {
+      Map<TopicPartition, Long> input = new HashMap<>();
+      input.put(topicPartition, timestamp);
+
+      Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes = this.consumer.offsetsForTimes(input);
+      if (future != null) {
+        future.complete(offsetsForTimes.get(topicPartition));
+      }
+    }, handler);
+  }
+
+
+  @Override
+  public void beginningOffsets(Set<TopicPartition> topicPartitions, Handler<AsyncResult<Map<TopicPartition, Long>>> handler) {
+    this.submitTask((consumer, future) -> {
+      Map<TopicPartition, Long> beginningOffsets = this.consumer.beginningOffsets(topicPartitions);
+      if (future != null) {
+        future.complete(beginningOffsets);
+      }
+    }, handler);
+  }
+
+  @Override
+  public void beginningOffsets(TopicPartition topicPartition, Handler<AsyncResult<Long>> handler) {
+    this.submitTask((consumer, future) -> {
+      Set<TopicPartition> input = new HashSet<>();
+      input.add(topicPartition);
+      Map<TopicPartition, Long> beginningOffsets = this.consumer.beginningOffsets(input);
+      if (future != null) {
+        future.complete(beginningOffsets.get(topicPartition));
+      }
+    }, handler);
+  }
+
+  @Override
+  public void endOffsets(Set<TopicPartition> topicPartitions, Handler<AsyncResult<Map<TopicPartition, Long>>> handler) {
+    this.submitTask((consumer, future) -> {
+      Map<TopicPartition, Long> endOffsets = this.consumer.endOffsets(topicPartitions);
+      if (future != null) {
+        future.complete(endOffsets);
+      }
+    }, handler);
+  }
+
+  @Override
+  public void endOffsets(TopicPartition topicPartition, Handler<AsyncResult<Long>> handler) {
+    this.submitTask((consumer, future) -> {
+      Set<TopicPartition> input = new HashSet<>();
+      input.add(topicPartition);
+      Map<TopicPartition, Long> endOffsets = this.consumer.endOffsets(input);
+      if (future != null) {
+        future.complete(endOffsets.get(topicPartition));
       }
     }, handler);
   }

--- a/src/main/java/io/vertx/kafka/client/package-info.java
+++ b/src/main/java/io/vertx/kafka/client/package-info.java
@@ -211,7 +211,7 @@
  * == Seeking in a topic partition
  *
  * Apache Kafka can retain messages for a long period of time and the consumer can seek inside a topic partition
- * and obtain arbitraty access to the messages.
+ * and obtain arbitrary access to the messages.
  *
  * You can use {@link io.vertx.kafka.client.consumer.KafkaConsumer#seek} to change the offset for reading at a specific
  * position
@@ -235,6 +235,34 @@
  * {@link examples.VertxKafkaClientExamples#exampleSeekToEnd}
  * ----
  *
+ * == Offset lookup
+ *
+ * You can use the beginningOffsets API introduced in Kafka 0.10.1.1 to get the first offset
+ * for a given partition. In contrast to {@link io.vertx.kafka.client.consumer.KafkaConsumer#seekToBeginning},
+ * it does not change the consumer's offset.
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.VertxKafkaClientExamples#exampleConsumerBeginningOffsets}
+ * ----
+ *
+ * You can use the endOffsets API introduced in Kafka 0.10.1.1 to get the last offset
+ * for a given partition. In contrast to {@link io.vertx.kafka.client.consumer.KafkaConsumer#seekToEnd},
+ * it does not change the consumer's offset.
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.VertxKafkaClientExamples#exampleConsumerEndOffsets}
+ * ----
+ *
+ * You can use the offsetsForTimes API introduced in Kafka 0.10.1.1 to look up an offset by
+ * timestamp, i.e. search parameter is an epoch timestamp and the call returns the lowest offset
+ * with ingestion timestamp >= given timestamp.
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.VertxKafkaClientExamples#exampleConsumerOffsetsForTimes}
+ * ----
  * == Message flow control
  *
  * A consumer can control the incoming message flow and pause/resume the read operation from a topic, e.g it

--- a/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
@@ -595,7 +595,7 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
     TopicPartition topicPartition= new TopicPartition("the_topic", 0);
     topicPartitions.add(topicPartition);
 
-    // Test contains three sub-tests, so we need to countdown three times for completion
+    // Test contains two sub-tests
     Async done = ctx.async(2);
     consumer.handler(handler -> {
       // nothing to do in this test
@@ -614,7 +614,6 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
             });
             consumer.beginningOffsets(topicPartition, beginningOffsetResult -> {
                 ctx.assertTrue(beginningOffsetResult.succeeded());
-                // expect one result
                 // beginning offset must be 0
                 ctx.assertEquals(0L, beginningOffsetResult.result());
                 done.countDown();
@@ -625,12 +624,14 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
             consumer.endOffsets(topicPartitions, endOffsetResult -> {
               ctx.assertTrue(endOffsetResult.succeeded());
               ctx.assertEquals(1, endOffsetResult.result().size());
+              // endOffset must be equal to the number of ingested messages
               ctx.assertEquals((long) numMessages, endOffsetResult.result().get(topicPartition));
               done.countDown();
             });
 
             consumer.endOffsets(topicPartition, endOffsetResult -> {
               ctx.assertTrue(endOffsetResult.succeeded());
+              // endOffset must be equal to the number of ingested messages
               ctx.assertEquals((long) numMessages, endOffsetResult.result());
               done.countDown();
             });
@@ -666,7 +667,7 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
 
     TopicPartition topicPartition= new TopicPartition("the_topic", 0);
 
-    // Test contains three sub-tests, so we need to countdown three times for completion
+    // Test contains two sub-tests
     Async done = ctx.async(2);
     consumer.handler(handler -> {
       // nothing to do in this test

--- a/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
@@ -24,6 +24,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.kafka.client.consumer.KafkaReadStream;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
@@ -34,7 +35,11 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -545,6 +550,162 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
       }
     });
     consumer.subscribe(Collections.singleton("the_topic"));
+  }
+
+
+
+  /*
+    Tests beginningOffset
+   */
+  @Test
+  public void testBeginningOffset(TestContext ctx) throws Exception {
+   testBeginningEndOffset(ctx, true);
+  }
+
+  /*
+    Teste endOffset (boolean parameter = false)
+   */
+  @Test
+  public void testEndOffset(TestContext ctx) throws Exception {
+    testBeginningEndOffset(ctx, false);
+  }
+
+  /*
+   Tests test beginningOffset or endOffset, depending on beginningOffset = true or false
+  */
+  public void testBeginningEndOffset(TestContext ctx, boolean beginningOffset) throws Exception {
+    KafkaCluster kafkaCluster = kafkaCluster().addBrokers(1).startup();
+    Async batch = ctx.async();
+    AtomicInteger index = new AtomicInteger();
+    int numMessages = 1000;
+    kafkaCluster.useTo().produceStrings(numMessages, batch::complete, () ->
+      new ProducerRecord<>("the_topic", 0, "key-" + index.get(), "value-" + index.getAndIncrement()));
+    batch.awaitSuccess(20000);
+
+    Properties config = kafkaCluster.useTo().getConsumerProperties("the_consumer", "the_consumer", OffsetResetStrategy.EARLIEST);
+    config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+    Context context = vertx.getOrCreateContext();
+    consumer = createConsumer(context, config);
+
+    consumer.exceptionHandler(ctx::fail);
+
+    Set<TopicPartition> topicPartitions = new HashSet<>();
+    TopicPartition topicPartition= new TopicPartition("the_topic", 0);
+    topicPartitions.add(topicPartition);
+
+    // Test contains three sub-tests, so we need to countdown three times for completion
+    Async done = ctx.async(2);
+    consumer.handler(handler -> {
+      // nothing to do in this test
+    });
+
+    consumer.subscribe(Collections.singleton("the_topic"), subscribeRes -> {
+        if (subscribeRes.succeeded()) {
+          if(beginningOffset) {
+            consumer.beginningOffsets(topicPartitions, beginningOffsetResult -> {
+              ctx.assertTrue(beginningOffsetResult.succeeded());
+              // expect one result
+              ctx.assertEquals(1, beginningOffsetResult.result().size());
+              // beginning offset must be 0
+              ctx.assertEquals(0L, beginningOffsetResult.result().get(topicPartition));
+              done.countDown();
+            });
+            consumer.beginningOffsets(topicPartition, beginningOffsetResult -> {
+                ctx.assertTrue(beginningOffsetResult.succeeded());
+                // expect one result
+                // beginning offset must be 0
+                ctx.assertEquals(0L, beginningOffsetResult.result());
+                done.countDown();
+              });
+          }
+          // Tests for endOffset
+          else {
+            consumer.endOffsets(topicPartitions, endOffsetResult -> {
+              ctx.assertTrue(endOffsetResult.succeeded());
+              ctx.assertEquals(1, endOffsetResult.result().size());
+              ctx.assertEquals((long) numMessages, endOffsetResult.result().get(topicPartition));
+              done.countDown();
+            });
+
+            consumer.endOffsets(topicPartition, endOffsetResult -> {
+              ctx.assertTrue(endOffsetResult.succeeded());
+              ctx.assertEquals((long) numMessages, endOffsetResult.result());
+              done.countDown();
+            });
+          }
+        } else {
+          ctx.fail(subscribeRes.cause());
+        }
+      }
+    );
+  }
+
+
+  @Test
+  public void testOffsetsForTimes(TestContext ctx) throws Exception {
+    KafkaCluster kafkaCluster = kafkaCluster().addBrokers(1).startup();
+    Async batch = ctx.async();
+    AtomicInteger index = new AtomicInteger();
+    int numMessages = 1000;
+    long beforeProduce = System.currentTimeMillis();
+    kafkaCluster.useTo().produceStrings(numMessages, batch::complete, () ->
+      new ProducerRecord<>("the_topic", 0, "key-" + index.get(), "value-" + index.getAndIncrement()));
+    batch.awaitSuccess(20000);
+    long produceDuration = System.currentTimeMillis() - beforeProduce;
+
+    Properties config = kafkaCluster.useTo().getConsumerProperties("the_consumer", "the_consumer", OffsetResetStrategy.EARLIEST);
+    config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+    Context context = vertx.getOrCreateContext();
+    consumer = createConsumer(context, config);
+
+    consumer.exceptionHandler(ctx::fail);
+
+    TopicPartition topicPartition= new TopicPartition("the_topic", 0);
+
+    // Test contains three sub-tests, so we need to countdown three times for completion
+    Async done = ctx.async(2);
+    consumer.handler(handler -> {
+      // nothing to do in this test
+    });
+
+    consumer.subscribe(Collections.singleton("the_topic"), subscribeRes -> {
+        if (subscribeRes.succeeded()) {
+          // search by timestamp
+          // take timestamp BEFORE start of ingestion and add half of the ingestion duration to it
+          long searchTimestamp = beforeProduce + (produceDuration / 2);
+          Map<TopicPartition, Long> topicAndTimestamp = new HashMap<>();
+          topicAndTimestamp.put(topicPartition, searchTimestamp);
+
+          consumer.offsetsForTimes(topicAndTimestamp, offsetSearchResult -> {
+            ctx.assertTrue(offsetSearchResult.succeeded());
+            ctx.assertEquals(1, offsetSearchResult.result().size());
+            OffsetAndTimestamp offsetAndTimestamp = offsetSearchResult.result().get(topicPartition);
+            // Offset must be somewhere between beginningOffset and endOffset
+            ctx.assertTrue(offsetAndTimestamp.offset() > 0L && offsetAndTimestamp.offset() <= (long)numMessages);
+            // Timestamp of returned offset must be at >= searchTimestamp
+            ctx.assertTrue(offsetAndTimestamp.timestamp() >= searchTimestamp);
+            done.countDown();
+          });
+
+          consumer.offsetsForTimes(topicPartition, searchTimestamp, offsetSearchResult -> {
+            ctx.assertTrue(offsetSearchResult.succeeded());
+            OffsetAndTimestamp offsetAndTimestamp = offsetSearchResult.result();
+            // Offset must be somewhere between beginningOffset and endOffset
+            ctx.assertTrue(offsetAndTimestamp.offset() > 0L && offsetAndTimestamp.offset() <= (long)numMessages);
+            // Timestamp of returned offset must be at >= searchTimestamp
+            ctx.assertTrue(offsetAndTimestamp.timestamp() >= searchTimestamp);
+            done.countDown();
+          });
+
+        } else {
+          ctx.fail(subscribeRes.cause());
+        }
+      }
+    );
   }
 
   <K, V> KafkaReadStream<K, V> createConsumer(Context context, Properties config) throws Exception {

--- a/src/test/java/io/vertx/kafka/client/tests/KafkaClusterTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/KafkaClusterTestBase.java
@@ -48,7 +48,11 @@ public class KafkaClusterTestBase extends KafkaTestBase {
     if (kafkaCluster != null) {
       kafkaCluster.shutdown();
       kafkaCluster = null;
-      dataDir.delete();
+      boolean delete = dataDir.delete();
+      // If files are still locked and a test fails: delete on exit to allow subsequent test execution
+      if(!delete) {
+        dataDir.deleteOnExit();
+      }
     }
   }
 }


### PR DESCRIPTION
Hi vert.x team,

this PR updates the Kafka version to 0.10.1. (see #6) . It adds a few new methods around offset lookup.
Added:
```
void offsetsForTimes(Map<TopicPartition, Long> topicPartitionTimestamps, Handler<AsyncResult<Map<TopicPartition, OffsetAndTimestamp>>> handler);
void offsetsForTimes(TopicPartition topicPartition, Long timestamp, Handler<AsyncResult<OffsetAndTimestamp>> handler);
```

```
void beginningOffsets(Set<TopicPartition> topicPartitions, Handler<AsyncResult<Map<TopicPartition, Long>>> handler);
void beginningOffsets(TopicPartition topicPartition, Handler<AsyncResult<Long>> handler);
```

```
  void endOffsets(Set<TopicPartition> topicPartitions, Handler<AsyncResult<Map<TopicPartition, Long>>> handler);
  void endOffsets(TopicPartition topicPartition, Handler<AsyncResult<Long>> handler);
```
plus test cases, documentation is updated.

Looking forward to your feedback!
Thanks, Tim