### PR TITLE
Fixes #5: javax.management.InstanceAlreadyExistsException after debezium update

### DIFF
--- a/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
@@ -235,6 +235,10 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
     config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
     Context context = vertx.getOrCreateContext();
     consumer = createConsumer(context, config);
+
+    // We need to rename the client to avoid javax.management.InstanceAlreadyExistsException
+    // see https://github.com/vert-x3/vertx-kafka-client/issues/5
+    config.setProperty("client.id", "the_consumer2");
     consumer2 = createConsumer(vertx, config);
     consumer.handler(rec -> {});
     consumer2.handler(rec -> {});


### PR DESCRIPTION
With debezium 0.36+ (see #5), `ConsumerTestBase.testRebalance` throws the below exception because *both consumer have the same id*
PR fixes this by renaming the second consumer to the_consumer2
@ppatierno Not sure if this is related to the Java Heap space issue at at, but it for sure doesn't hurt to have that fixed. The issue shows up in Jenkins log just before the Heap Space meltdown starts, so who knows...

OT: Could you give me some info on the JVM config on the Jenkins server? Especially memory stuff? I cannot reproduce the issue locally. Thanks!

```
javax.management.InstanceAlreadyExistsException: kafka.consumer:type=app-info,id=the_consumer
	at com.sun.jmx.mbeanserver.Repository.addMBean(Repository.java:437)
	at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerWithRepository(DefaultMBeanServerInterceptor.java:1898)
	at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerDynamicMBean(DefaultMBeanServerInterceptor.java:966)
	at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerObject(DefaultMBeanServerInterceptor.java:900)
	at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerMBean(DefaultMBeanServerInterceptor.java:324)
	at com.sun.jmx.mbeanserver.JmxMBeanServer.registerMBean(JmxMBeanServer.java:522)
	at org.apache.kafka.common.utils.AppInfoParser.registerAppInfo(AppInfoParser.java:58)
	at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:695)
	at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:584)
	at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:566)
	at io.vertx.kafka.client.consumer.KafkaReadStream.create(KafkaReadStream.java:57)
	at io.vertx.kafka.client.tests.ConsumerTest.createConsumer(ConsumerTest.java:31)
	at io.vertx.kafka.client.tests.ConsumerTestBase.testRebalance(ConsumerTestBase.java:242)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at io.vertx.ext.unit.junit.VertxUnitRunner.invokeTestMethod(VertxUnitRunner.java:95)
	at io.vertx.ext.unit.junit.VertxUnitRunner.lambda$invokeExplosively$0(VertxUnitRunner.java:114)
	at io.vertx.ext.unit.impl.TestContextImpl$Step.run(TestContextImpl.java:122)
	at io.vertx.ext.unit.impl.TestContextImpl$Step.access$600(TestContextImpl.java:30)
	at io.vertx.ext.unit.impl.TestContextImpl.run(TestContextImpl.java:221)
	at io.vertx.ext.unit.junit.VertxUnitRunner.invokeExplosively(VertxUnitRunner.java:130)
	at io.vertx.ext.unit.junit.VertxUnitRunner.access$000(VertxUnitRunner.java:39)
	at io.vertx.ext.unit.junit.VertxUnitRunner$1.evaluate(VertxUnitRunner.java:84)
	at io.vertx.ext.unit.junit.VertxUnitRunner$2.evaluate(VertxUnitRunner.java:196)
	at io.vertx.ext.unit.junit.VertxUnitRunner$3.evaluate(VertxUnitRunner.java:211)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:51)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:237)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
2017-03-10 08:50:20,042 WARN  KAF Error registering AppInfo mbean
```
