### PR TITLE
Refactored tests to reduce memory consumption and reduce total runtime

### DIFF
--- a/src/test/java/io/vertx/kafka/client/tests/KafkaClusterTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/KafkaClusterTestBase.java
@@ -21,9 +21,12 @@ import io.debezium.util.Testing;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import java.io.File;
+import java.io.IOException;
 
 /**
  * Base class for tests providing a Kafka cluster
@@ -31,10 +34,10 @@ import java.io.File;
 @RunWith(VertxUnitRunner.class)
 public class KafkaClusterTestBase extends KafkaTestBase {
 
-  private File dataDir;
-  private KafkaCluster kafkaCluster;
+  private static File dataDir;
+  protected static KafkaCluster kafkaCluster;
 
-  protected KafkaCluster kafkaCluster() {
+  protected static KafkaCluster kafkaCluster() {
     if (kafkaCluster != null) {
       throw new IllegalStateException();
     }
@@ -43,8 +46,14 @@ public class KafkaClusterTestBase extends KafkaTestBase {
     return kafkaCluster;
   }
 
-  @After
-  public void afterTest(TestContext ctx) {
+  @BeforeClass
+  public static void setUp(TestContext ctx) throws IOException {
+    kafkaCluster = kafkaCluster().deleteDataPriorToStartup(true).addBrokers(1).startup();
+  }
+
+
+  @AfterClass
+  public static void tearDown(TestContext ctx) {
     if (kafkaCluster != null) {
       kafkaCluster.shutdown();
       kafkaCluster = null;

--- a/src/test/java/io/vertx/kafka/client/tests/RxConsumerTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/RxConsumerTest.java
@@ -1,6 +1,5 @@
 package io.vertx.kafka.client.tests;
 
-import io.debezium.kafka.KafkaCluster;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.rxjava.core.Vertx;
@@ -34,19 +33,18 @@ public class RxConsumerTest extends KafkaClusterTestBase {
     close(ctx, consumer::close);
     consumer = null;
     vertx.close(ctx.asyncAssertSuccess());
-    super.afterTest(ctx);
   }
 
   @Test
   public void testConsume(TestContext ctx) throws Exception {
-    KafkaCluster kafkaCluster = kafkaCluster().addBrokers(1).startup();
+    String topicName = "testConsume";
     Async batch = ctx.async();
     AtomicInteger index = new AtomicInteger();
     int numMessages = 1000;
     kafkaCluster.useTo().produceStrings(numMessages, batch::complete,  () ->
-      new ProducerRecord<>("the_topic", 0, "key-" + index.get(), "value-" + index.getAndIncrement()));
+      new ProducerRecord<>(topicName, 0, "key-" + index.get(), "value-" + index.getAndIncrement()));
     batch.awaitSuccess(20000);
-    Properties config = kafkaCluster.useTo().getConsumerProperties("the_consumer", "the_consumer", OffsetResetStrategy.EARLIEST);
+    Properties config = kafkaCluster.useTo().getConsumerProperties("testConsume_consumer", "testConsume_consumer", OffsetResetStrategy.EARLIEST);
     Map<String ,String> map = mapConfig(config);
     consumer = KafkaConsumer.create(vertx, map, String.class, String.class);
     Async done = ctx.async();
@@ -56,6 +54,6 @@ public class RxConsumerTest extends KafkaClusterTestBase {
         done.complete();
       }
     }, ctx::fail);
-    consumer.subscribe(Collections.singleton("the_topic"));
+    consumer.subscribe(Collections.singleton(topicName));
   }
 }


### PR DESCRIPTION
Hi, @ppatierno!

I refactored the tests which invoke a real Kafka Broker. Kafka Broker is now started in BeforeClass, i.e. all tests per class share the same Broker. Therefore, the tests now use different topic names, consumer names, and producer names.

**Advantage: total test duration on my Laptop does down from approx. 2:30 minutes to approx. 1:02. Next, the GC shouldn't be as busy as before anymore.** I haven't seen Java Heap Space problems since the.

There is one problem which I think also exists in the original test:
`CleanupTest.testCleanupInConsumer` very rarely fails with a "Already Undeployed Exception" and it also does fail quite often without a Thread.sleep after undeploy & check for active Threads. Do you have an idea ?

Best, Tim