### PR TITLE
Fixes #30: NullPointerException in KafkaProducerImpl if write is called without callback

### DIFF
--- a/src/main/java/io/vertx/kafka/client/producer/impl/KafkaProducerImpl.java
+++ b/src/main/java/io/vertx/kafka/client/producer/impl/KafkaProducerImpl.java
@@ -136,14 +136,15 @@ public class KafkaProducerImpl<K, V> implements KafkaProducer<K, V> {
   @SuppressWarnings("unchecked")
   public KafkaProducer<K, V> write(KafkaProducerRecord<K, V> record, Handler<AsyncResult<RecordMetadata>> handler) {
     this.stream.write(record.record(), done -> {
-
-      if (done.succeeded()) {
-        handler.handle(Future.succeededFuture(Helper.from(done.result())));
-      } else {
-        handler.handle(Future.failedFuture(done.cause()));
+      if (handler != null) {
+        if (done.succeeded()) {
+          handler.handle(Future.succeededFuture(Helper.from(done.result())));
+        } else {
+          handler.handle(Future.failedFuture(done.cause()));
+        }
       }
-
     });
+
     return this;
   }
 


### PR DESCRIPTION
Introduces a NullCheck and adds a regression test