### PR TITLE
Fixes #33 NPE in KafkaConsumerImpl.offsetForTimes

### DIFF
--- a/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
+++ b/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
@@ -115,17 +115,12 @@ public class Helper {
     );
   }
 
-  public static Map<org.apache.kafka.common.TopicPartition, org.apache.kafka.clients.consumer.OffsetAndTimestamp> toTopicPartitionOffsetAndTimestamp(Map<TopicPartition, OffsetAndTimestamp> topicPartitionOffsetAndTimestamps) {
-    return topicPartitionOffsetAndTimestamps.entrySet().stream().collect(Collectors.toMap(
-      e -> new org.apache.kafka.common.TopicPartition(e.getKey().getTopic(), e.getKey().getPartition()),
-      e -> new org.apache.kafka.clients.consumer.OffsetAndTimestamp(e.getValue().getOffset(), e.getValue().getTimestamp()))
-    );
-  }
-
   public static Map<TopicPartition, OffsetAndTimestamp> fromTopicPartitionOffsetAndTimestamp(Map<org.apache.kafka.common.TopicPartition, org.apache.kafka.clients.consumer.OffsetAndTimestamp> topicPartitionOffsetAndTimestamps) {
-    return topicPartitionOffsetAndTimestamps.entrySet().stream().collect(Collectors.toMap(
-      e -> new TopicPartition(e.getKey().topic(), e.getKey().partition()),
-      e -> new OffsetAndTimestamp(e.getValue().offset(), e.getValue().timestamp()))
-    );
+    return topicPartitionOffsetAndTimestamps.entrySet().stream()
+      .filter(e-> e.getValue() != null)
+      .collect(Collectors.toMap(
+        e -> new TopicPartition(e.getKey().topic(), e.getKey().partition()),
+        e ->new OffsetAndTimestamp(e.getValue().offset(), e.getValue().timestamp()))
+      );
   }
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
@@ -65,7 +65,7 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
    * Create a new KafkaConsumer instance
    *
    * @param vertx Vert.x instance to use
-   * @param config  Kafka producer configuration
+   * @param config Kafka consumer configuration
    * @return  an instance of the KafkaConsumer
    */
   static <K, V> KafkaConsumer<K, V> create(Vertx vertx, Map<String, String> config) {
@@ -92,7 +92,7 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
    * Create a new KafkaConsumer instance
    *
    * @param vertx Vert.x instance to use
-   * @param config  Kafka producer configuration
+   * @param config Kafka consumer configuration
    * @return  an instance of the KafkaConsumer
    */
   @GenIgnore
@@ -105,7 +105,7 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
    * Create a new KafkaConsumer instance
    *
    * @param vertx Vert.x instance to use
-   * @param config  Kafka consumer configuration
+   * @param config Kafka consumer configuration
    * @param keyType class type for the key deserialization
    * @param valueType class type for the value deserialization
    * @return  an instance of the KafkaConsumer
@@ -526,7 +526,8 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
   void position(TopicPartition partition, Handler<AsyncResult<Long>> handler);
 
   /**
-   * Look up the offsets for the given partitions by timestamp.
+   * Look up the offsets for the given partitions by timestamp. Note: the result might be empty in case
+   * for the given timestamp no offset can be found -- e.g., when the timestamp refers to the future
    * @param topicPartitionTimestamps A map with pairs of (TopicPartition, Timestamp).
    * @param handler handler called on operation completed
    */
@@ -534,7 +535,8 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
   void offsetsForTimes(Map<TopicPartition, Long> topicPartitionTimestamps, Handler<AsyncResult<Map<TopicPartition, OffsetAndTimestamp>>> handler);
 
   /**
-   * Look up the offset for the given partition by timestamp.
+   * Look up the offset for the given partition by timestamp. Note: the result might be null in case
+   * for the given timestamp no offset can be found -- e.g., when the timestamp refers to the future
    * @param topicPartition TopicPartition to query.
    * @param timestamp Timestamp to be used in the query.
    * @param handler handler called on operation completed


### PR DESCRIPTION
1. Introduces proper handling of OffsetAndTimestamp being null as a result of offsetForTimes. This can be the case if a timestamp is requested that is greater than the latest timestamp in the queried topic.
2. Added a Regression test
3. Changed documentation according

