### PR TITLE
Fix erroneous error in CleanupTest.testCleanupInConsumer

### DIFF
--- a/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
@@ -733,6 +733,7 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
     io.vertx.kafka.client.common.TopicPartition topicPartition = new io.vertx.kafka.client.common.TopicPartition(topicName, 0);
 
     Async done = ctx.async(2);
+    done.handler(r -> wrappedConsumer.close());
     wrappedConsumer.handler(handler -> {
       // nothing to do in this test
     });


### PR DESCRIPTION
I was getting "Was expecting the consumer to be closed", but it's actually seeing a thread for a consumer started in a different test. I'm guessing that in other test environments the CleanupTest runs before the ConsumerTest.