### PR TITLE
Fix #39 by exposing first-,last-in-batch in KafkaConsumerRecord

### DIFF
--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
@@ -502,6 +502,14 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
    */
   @Fluent
   KafkaConsumer<K, V> partitionsFor(String topic, Handler<AsyncResult<List<PartitionInfo>>> handler);
+  
+  /**
+   * Set the handler to be used when batches of messages are fetched 
+   * from the Kafka server
+   * @param handler handler called when batches of messages are fetched
+   * @return current KafkaConsumer instance
+   */
+  KafkaConsumer<K, V> batchHandler(Handler<KafkaConsumerRecords<K, V>> handler);
 
   /**
    * Close the consumer

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
@@ -509,6 +509,7 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
    * @param handler handler called when batches of messages are fetched
    * @return current KafkaConsumer instance
    */
+  @Fluent
   KafkaConsumer<K, V> batchHandler(Handler<KafkaConsumerRecords<K, V>> handler);
 
   /**

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumerRecords.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumerRecords.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.vertx.kafka.client.consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecords;

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumerRecords.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumerRecords.java
@@ -1,0 +1,34 @@
+package io.vertx.kafka.client.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * Vert.x Kafka consumer records
+ */
+@VertxGen
+public interface KafkaConsumerRecords<K, V> {
+  /**
+   * @return the total number of records in this batch
+   */
+  int size();
+  /**
+   * @return whether this batch contains any records
+   */
+  boolean isEmpty();
+  /**
+   * Get the record at the given index
+   * @param index the index of the record to get
+   * @throws IndexOutOfBoundsException if index <0 or index>={@link #size()}
+   */
+  KafkaConsumerRecord<K, V> recordAt(int index);
+  
+  /**
+   * @return  the native Kafka consumer records with backed information
+   */
+  @GenIgnore
+  ConsumerRecords<K, V> records();
+  
+}

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
@@ -24,6 +24,7 @@ import io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl;
 import io.vertx.kafka.client.serialization.VertxSerdes;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.PartitionInfo;
@@ -408,5 +409,14 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
    * @return the underlying consumer
    */
   Consumer<K, V> unwrap();
+
+  /**
+   * Set the handler that will be called when a new batch of records is 
+   * returned from Kafka.
+   * 
+   * @param handler
+   * @return current KafkaReadStream instance
+   */
+  KafkaReadStream<K, V> batchHandler(Handler<ConsumerRecords<K, V>> handler);
 
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
@@ -28,6 +28,7 @@ import io.vertx.kafka.client.common.PartitionInfo;
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecords;
 import io.vertx.kafka.client.consumer.KafkaReadStream;
 import io.vertx.kafka.client.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -515,5 +516,13 @@ public class KafkaConsumerImpl<K, V> implements KafkaConsumer<K, V> {
   @Override
   public Consumer<K, V> unwrap() {
     return this.stream.unwrap();
+  }
+
+  @Override
+  public KafkaConsumer<K, V> batchHandler(Handler<KafkaConsumerRecords<K, V>> handler) {
+    stream.batchHandler(records -> {
+      handler.handle(new KafkaConsumerRecordsImpl<>(records));
+    });
+    return this;
   }
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerRecordsImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerRecordsImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.vertx.kafka.client.consumer.impl;
 
 import java.util.ArrayList;
@@ -31,7 +46,7 @@ public class KafkaConsumerRecordsImpl<K, V> implements KafkaConsumerRecords<K, V
   public KafkaConsumerRecord<K, V> recordAt(int index) {
     if (list == null) {
       list = new ArrayList<>(records.count());
-      records.forEach(r -> list.add(new KafkaConsumerRecordImpl<K, V>(r)));
+      records.forEach(record -> list.add(new KafkaConsumerRecordImpl<K, V>(record)));
     }
     return list.get(index);
   }

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerRecordsImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerRecordsImpl.java
@@ -1,0 +1,44 @@
+package io.vertx.kafka.client.consumer.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecords;
+
+public class KafkaConsumerRecordsImpl<K, V> implements KafkaConsumerRecords<K, V>{
+
+  private final ConsumerRecords<K, V> records;
+  private List<KafkaConsumerRecord<K, V>> list;
+
+  public KafkaConsumerRecordsImpl(ConsumerRecords<K, V> records) {
+    this.records = records;
+  }
+  
+  @Override
+  public int size() {
+    return records.count();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return records.isEmpty();
+  }
+
+  @Override
+  public KafkaConsumerRecord<K, V> recordAt(int index) {
+    if (list == null) {
+      list = new ArrayList<>(records.count());
+      records.forEach(r -> list.add(new KafkaConsumerRecordImpl<K, V>(r)));
+    }
+    return list.get(index);
+  }
+
+  @Override
+  public ConsumerRecords<K, V> records() {
+    return records;
+  }
+
+}

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
@@ -21,6 +21,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.kafka.client.common.impl.Helper;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.consumer.KafkaReadStream;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
@@ -60,6 +61,7 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
   private final AtomicBoolean paused = new AtomicBoolean(true);
   private Handler<ConsumerRecord<K, V>> recordHandler;
   private Iterator<ConsumerRecord<K, V>> current; // Accessed on event loop
+  private Handler<ConsumerRecords<K, V>> batchHandler;
   private Handler<Set<TopicPartition>> partitionsRevokedHandler;
   private Handler<Set<TopicPartition>> partitionsAssignedHandler;
 
@@ -160,6 +162,9 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
 
         if (records != null && records.count() > 0) {
           this.current = records.iterator();
+          if (batchHandler != null) {
+            batchHandler.handle(records);
+          }
           this.schedule(0);
         } else {
           this.schedule(1);
@@ -607,5 +612,10 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
   @Override
   public Consumer<K, V> unwrap() {
     return this.consumer;
+  }
+  
+  public KafkaReadStream batchHandler(Handler<ConsumerRecords<K, V>> handler) {
+    this.batchHandler = handler;
+    return this;
   }
 }

--- a/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
@@ -804,8 +804,8 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
     batchHandler.handler(ar -> wrappedConsumer.close());
     wrappedConsumer.batchHandler(records -> {
       ctx.assertEquals(numMessages, records.size());
-      for (int ii = 0; ii < records.size(); ii++) {
-        KafkaConsumerRecord<Object, Object> record = records.recordAt(ii);
+      for (int i = 0; i < records.size(); i++) {
+        KafkaConsumerRecord<Object, Object> record = records.recordAt(i);
         int dec = count.decrementAndGet();
         if (dec >= 0) {
           ctx.assertEquals("key-" + (numMessages - dec - 1), record.key());

--- a/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
@@ -771,7 +771,8 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
     Properties config = kafkaCluster.useTo().getConsumerProperties(consumerId, consumerId, OffsetResetStrategy.EARLIEST);
     config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
     config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    consumer = createConsumer(vertx, config);
+    Context context = vertx.getOrCreateContext();
+    consumer = createConsumer(context, config);
     Async batchHandler = ctx.async();
     consumer.batchHandler(records -> {
       ctx.assertEquals(numMessages, records.count());


### PR DESCRIPTION
This is a fairly minimal change to address #39, but it changes the API of KafkaReadStream to be a ReadStream<KafkaConsumerRecord> (was ReadStream<ConsumerRecord>), consequently:

1. It's a breaking change for clients of the KafakReadStream
2. Because it needs to instantiate a new KafkaConsumerRecord for each record it will be less performant (slower, more GC).

I'm open to implementing better ways to address #39, if anyone has any better ideas, but if this is an acceptable approach let me know and I'll add some tests.