### PR TITLE
Javadoc

### DIFF
--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
@@ -505,7 +505,9 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
   
   /**
    * Set the handler to be used when batches of messages are fetched 
-   * from the Kafka server
+   * from the Kafka server. Batch handlers need to take care not to block 
+   * the event loop when dealing with large batches. It is better to process
+   * records individually using the {@link #handler(Handler) record handler}.
    * @param handler handler called when batches of messages are fetched
    * @return current KafkaConsumer instance
    */

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
@@ -412,10 +412,12 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
 
   /**
    * Set the handler that will be called when a new batch of records is 
-   * returned from Kafka.
+   * returned from Kafka. Batch handlers need to take care not to block 
+   * the event loop when dealing with large batches. It is better to process
+   * records individually using the {@link #handler(Handler) record handler}.
    * 
-   * @param handler
-   * @return current KafkaReadStream instance
+   * @param handler handler called each time Kafka returns a batch of records.
+   * @return current KafkaReadStream instance.
    */
   KafkaReadStream<K, V> batchHandler(Handler<ConsumerRecords<K, V>> handler);
 


### PR DESCRIPTION
In conversation with @ppatierno it became apparent that we need some javadoc so users know to avoid trying to process all the messages in the batch using the batch handler. They should use the record handler, since that yields every 10 messages, thus is much less prone to blocking the event loop.