### PR TITLE
Issue 48 doc

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -323,6 +323,16 @@ order to only consume messages starting from a particular offset, for example.
 Calling `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#assignment-io.vertx.core.Handler-[assignment]` provides
 the list of the current assigned partitions.
 
+== Changing the subscription or assignment
+
+You can change the subscribed topics, or assigned partitions after you have started to consume messages, simply 
+by calling `subscribe()` or `assign()` again. 
+
+Note that due to internal buffering of messages it is possible that the record handler will continue to 
+observe messages from the old subscription or assignment _after_ the `subscribe()` or `assign()` 
+method's completion handler has been called. This is not the case for messages observed by the batch handler: 
+Once the completion handler has been called it will only observe messages read from the subscription or assignment.
+
 == Getting topic partition information
 
 You can call the `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#partitionsFor-java.lang.String-io.vertx.core.Handler-[partitionsFor]` to get information about
@@ -459,6 +469,11 @@ consumer.seekToEnd(java.util.Collections.singleton(topicPartition), { done ->
 
 ----
 
+Note that due to internal buffering of messages it is possible that the record handler will continue to 
+observe messages read from the original offset for a time _after_ the `seek*()` method's completion 
+handler has been called. This is not the case for messages observed by the batch handler: Once the
+`seek*()` completion handler has been called it will only observe messages read from the new offset.
+
 == Offset lookup
 
 You can use the beginningOffsets API introduced in Kafka 0.10.1.1 to get the first offset
@@ -541,7 +556,13 @@ can pause the message flow when it needs more time to process the actual message
 to continue message processing.
 
 To achieve that you can use `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#pause--[pause]` and
-`link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#resume--[resume]`
+`link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#resume--[resume]`.
+
+In the case of the partition-specific pause and resume it is possible that the record handler will continue to 
+observe messages from a paused partition for a time _after_ the `pause()` method's completion 
+handler has been called. This is not the case for messages observed by the batch handler: Once the
+`pause()` completion handler has been called it will only observe messages from those partitions which 
+rare not paused.
 
 [source,groovy]
 ----

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -292,6 +292,16 @@ order to only consume messages starting from a particular offset, for example.
 Calling `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#assignment-io.vertx.core.Handler-[assignment]` provides
 the list of the current assigned partitions.
 
+== Changing the subscription or assignment
+
+You can change the subscribed topics, or assigned partitions after you have started to consume messages, simply 
+by calling `subscribe()` or `assign()` again. 
+
+Note that due to internal buffering of messages it is possible that the record handler will continue to 
+observe messages from the old subscription or assignment _after_ the `subscribe()` or `assign()` 
+method's completion handler has been called. This is not the case for messages observed by the batch handler: 
+Once the completion handler has been called it will only observe messages read from the subscription or assignment.
+
 == Getting topic partition information
 
 You can call the `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#partitionsFor-java.lang.String-io.vertx.core.Handler-[partitionsFor]` to get information about
@@ -407,6 +417,11 @@ consumer.seekToEnd(Collections.singleton(topicPartition), done -> {
 });
 ----
 
+Note that due to internal buffering of messages it is possible that the record handler will continue to 
+observe messages read from the original offset for a time _after_ the `seek*()` method's completion 
+handler has been called. This is not the case for messages observed by the batch handler: Once the
+`seek*()` completion handler has been called it will only observe messages read from the new offset.
+
 == Offset lookup
 
 You can use the beginningOffsets API introduced in Kafka 0.10.1.1 to get the first offset
@@ -511,7 +526,13 @@ can pause the message flow when it needs more time to process the actual message
 to continue message processing.
 
 To achieve that you can use `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#pause--[pause]` and
-`link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#resume--[resume]`
+`link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#resume--[resume]`.
+
+In the case of the partition-specific pause and resume it is possible that the record handler will continue to 
+observe messages from a paused partition for a time _after_ the `pause()` method's completion 
+handler has been called. This is not the case for messages observed by the batch handler: Once the
+`pause()` completion handler has been called it will only observe messages from those partitions which 
+rare not paused.
 
 [source,java]
 ----

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -327,6 +327,16 @@ order to only consume messages starting from a particular offset, for example.
 Calling `link:../../jsdoc/module-vertx-kafka-client-js_kafka_consumer-KafkaConsumer.html#assignment[assignment]` provides
 the list of the current assigned partitions.
 
+== Changing the subscription or assignment
+
+You can change the subscribed topics, or assigned partitions after you have started to consume messages, simply 
+by calling `subscribe()` or `assign()` again. 
+
+Note that due to internal buffering of messages it is possible that the record handler will continue to 
+observe messages from the old subscription or assignment _after_ the `subscribe()` or `assign()` 
+method's completion handler has been called. This is not the case for messages observed by the batch handler: 
+Once the completion handler has been called it will only observe messages read from the subscription or assignment.
+
 == Getting topic partition information
 
 You can call the `link:../../jsdoc/module-vertx-kafka-client-js_kafka_consumer-KafkaConsumer.html#partitionsFor[partitionsFor]` to get information about
@@ -463,6 +473,11 @@ consumer.seekToEnd(Java.type("java.util.Collections").singleton(topicPartition),
 
 ----
 
+Note that due to internal buffering of messages it is possible that the record handler will continue to 
+observe messages read from the original offset for a time _after_ the `seek*()` method's completion 
+handler has been called. This is not the case for messages observed by the batch handler: Once the
+`seek*()` completion handler has been called it will only observe messages read from the new offset.
+
 == Offset lookup
 
 You can use the beginningOffsets API introduced in Kafka 0.10.1.1 to get the first offset
@@ -545,7 +560,13 @@ can pause the message flow when it needs more time to process the actual message
 to continue message processing.
 
 To achieve that you can use `link:../../jsdoc/module-vertx-kafka-client-js_kafka_consumer-KafkaConsumer.html#pause[pause]` and
-`link:../../jsdoc/module-vertx-kafka-client-js_kafka_consumer-KafkaConsumer.html#resume[resume]`
+`link:../../jsdoc/module-vertx-kafka-client-js_kafka_consumer-KafkaConsumer.html#resume[resume]`.
+
+In the case of the partition-specific pause and resume it is possible that the record handler will continue to 
+observe messages from a paused partition for a time _after_ the `pause()` method's completion 
+handler has been called. This is not the case for messages observed by the batch handler: Once the
+`pause()` completion handler has been called it will only observe messages from those partitions which 
+rare not paused.
 
 [source,js]
 ----

--- a/src/main/asciidoc/kotlin/index.adoc
+++ b/src/main/asciidoc/kotlin/index.adoc
@@ -322,6 +322,16 @@ order to only consume messages starting from a particular offset, for example.
 Calling `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#assignment-io.vertx.core.Handler-[assignment]` provides
 the list of the current assigned partitions.
 
+== Changing the subscription or assignment
+
+You can change the subscribed topics, or assigned partitions after you have started to consume messages, simply 
+by calling `subscribe()` or `assign()` again. 
+
+Note that due to internal buffering of messages it is possible that the record handler will continue to 
+observe messages from the old subscription or assignment _after_ the `subscribe()` or `assign()` 
+method's completion handler has been called. This is not the case for messages observed by the batch handler: 
+Once the completion handler has been called it will only observe messages read from the subscription or assignment.
+
 == Getting topic partition information
 
 You can call the `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#partitionsFor-java.lang.String-io.vertx.core.Handler-[partitionsFor]` to get information about
@@ -456,6 +466,11 @@ consumer.seekToEnd(java.util.Collections.singleton(topicPartition), { done ->
 
 ----
 
+Note that due to internal buffering of messages it is possible that the record handler will continue to 
+observe messages read from the original offset for a time _after_ the `seek*()` method's completion 
+handler has been called. This is not the case for messages observed by the batch handler: Once the
+`seek*()` completion handler has been called it will only observe messages read from the new offset.
+
 == Offset lookup
 
 You can use the beginningOffsets API introduced in Kafka 0.10.1.1 to get the first offset
@@ -538,7 +553,13 @@ can pause the message flow when it needs more time to process the actual message
 to continue message processing.
 
 To achieve that you can use `link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#pause--[pause]` and
-`link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#resume--[resume]`
+`link:../../apidocs/io/vertx/kafka/client/consumer/KafkaConsumer.html#resume--[resume]`.
+
+In the case of the partition-specific pause and resume it is possible that the record handler will continue to 
+observe messages from a paused partition for a time _after_ the `pause()` method's completion 
+handler has been called. This is not the case for messages observed by the batch handler: Once the
+`pause()` completion handler has been called it will only observe messages from those partitions which 
+rare not paused.
 
 [source,kotlin]
 ----

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -327,6 +327,16 @@ order to only consume messages starting from a particular offset, for example.
 Calling `link:../../yardoc/VertxKafkaClient/KafkaConsumer.html#assignment-instance_method[assignment]` provides
 the list of the current assigned partitions.
 
+== Changing the subscription or assignment
+
+You can change the subscribed topics, or assigned partitions after you have started to consume messages, simply 
+by calling `subscribe()` or `assign()` again. 
+
+Note that due to internal buffering of messages it is possible that the record handler will continue to 
+observe messages from the old subscription or assignment _after_ the `subscribe()` or `assign()` 
+method's completion handler has been called. This is not the case for messages observed by the batch handler: 
+Once the completion handler has been called it will only observe messages read from the subscription or assignment.
+
 == Getting topic partition information
 
 You can call the `link:../../yardoc/VertxKafkaClient/KafkaConsumer.html#partitions_for-instance_method[partitionsFor]` to get information about
@@ -463,6 +473,11 @@ consumer.seek_to_end(Java::JavaUtil::Collections.singleton(topicPartition)) { |d
 
 ----
 
+Note that due to internal buffering of messages it is possible that the record handler will continue to 
+observe messages read from the original offset for a time _after_ the `seek*()` method's completion 
+handler has been called. This is not the case for messages observed by the batch handler: Once the
+`seek*()` completion handler has been called it will only observe messages read from the new offset.
+
 == Offset lookup
 
 You can use the beginningOffsets API introduced in Kafka 0.10.1.1 to get the first offset
@@ -545,7 +560,13 @@ can pause the message flow when it needs more time to process the actual message
 to continue message processing.
 
 To achieve that you can use `link:../../yardoc/VertxKafkaClient/KafkaConsumer.html#pause-instance_method[pause]` and
-`link:../../yardoc/VertxKafkaClient/KafkaConsumer.html#resume-instance_method[resume]`
+`link:../../yardoc/VertxKafkaClient/KafkaConsumer.html#resume-instance_method[resume]`.
+
+In the case of the partition-specific pause and resume it is possible that the record handler will continue to 
+observe messages from a paused partition for a time _after_ the `pause()` method's completion 
+handler has been called. This is not the case for messages observed by the batch handler: Once the
+`pause()` completion handler has been called it will only observe messages from those partitions which 
+rare not paused.
 
 [source,ruby]
 ----

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
@@ -157,7 +157,15 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
 
   /**
    * Subscribe to the given topic to get dynamically assigned partitions.
-   *
+   * <p>
+   * Due to internal buffering of messages, when changing the subscribed topic  
+   * the old topic may remain in effect 
+   * (as observed by the {@linkplain #handler(Handler)} record handler}) 
+   * until some time <em>after</em> the given {@code completionHandler} 
+   * is called. In contrast, the once the given {@code completionHandler} 
+   * is called the {@link #batchHandler(Handler)} will only see messages 
+   * consistent with the new topic.
+   * 
    * @param topic  topic to subscribe to
    * @param completionHandler handler called on operation completed
    * @return  current KafkaConsumer instance
@@ -167,7 +175,15 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
 
   /**
    * Subscribe to the given list of topics to get dynamically assigned partitions.
-   *
+   * <p>
+   * Due to internal buffering of messages, when changing the subscribed topics  
+   * the old set of topics may remain in effect 
+   * (as observed by the {@linkplain #handler(Handler)} record handler}) 
+   * until some time <em>after</em> the given {@code completionHandler} 
+   * is called. In contrast, the once the given {@code completionHandler} 
+   * is called the {@link #batchHandler(Handler)} will only see messages 
+   * consistent with the new set of topics.
+   * 
    * @param topics  topics to subscribe to
    * @param completionHandler handler called on operation completed
    * @return  current KafkaConsumer instance
@@ -195,7 +211,15 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
 
   /**
    * Manually assign a partition to this consumer.
-   *
+   * <p>
+   * Due to internal buffering of messages, when reassigning
+   * the old partition may remain in effect 
+   * (as observed by the {@linkplain #handler(Handler)} record handler)} 
+   * until some time <em>after</em> the given {@code completionHandler} 
+   * is called. In contrast, the once the given {@code completionHandler} 
+   * is called the {@link #batchHandler(Handler)} will only see messages 
+   * consistent with the new partition.
+   * 
    * @param topicPartition  partition which want assigned
    * @param completionHandler handler called on operation completed
    * @return  current KafkaConsumer instance
@@ -205,7 +229,15 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
 
   /**
    * Manually assign a list of partition to this consumer.
-   *
+   * <p>
+   * Due to internal buffering of messages, when reassigning
+   * the old set of partitions may remain in effect 
+   * (as observed by the {@linkplain #handler(Handler)} record handler)} 
+   * until some time <em>after</em> the given {@code completionHandler} 
+   * is called. In contrast, the once the given {@code completionHandler} 
+   * is called the {@link #batchHandler(Handler)} will only see messages 
+   * consistent with the new set of partitions.
+   * 
    * @param topicPartitions  partitions which want assigned
    * @param completionHandler handler called on operation completed
    * @return  current KafkaConsumer instance
@@ -278,7 +310,15 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
 
   /**
    * Suspend fetching from the requested partition.
-   *
+   * <p>
+   * Due to internal buffering of messages,
+   * the {@linkplain #handler(Handler) record handler} will 
+   * continue to observe messages from the given {@code topicParation} 
+   * until some time <em>after</em> the given {@code completionHandler} 
+   * is called. In contrast, the once the given {@code completionHandler} 
+   * is called the {@link #batchHandler(Handler)} will not see messages 
+   * from the given {@code topicParation}.
+   * 
    * @param topicPartition topic partition from which suspend fetching
    * @param completionHandler handler called on operation completed
    * @return  current KafkaConsumer instance
@@ -288,7 +328,15 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
 
   /**
    * Suspend fetching from the requested partitions.
-   *
+   * <p>
+   * Due to internal buffering of messages,
+   * the {@linkplain #handler(Handler) record handler} will 
+   * continue to observe messages from the given {@code topicParations} 
+   * until some time <em>after</em> the given {@code completionHandler} 
+   * is called. In contrast, the once the given {@code completionHandler} 
+   * is called the {@link #batchHandler(Handler)} will not see messages 
+   * from the given {@code topicParations}.
+   * 
    * @param topicPartitions topic partition from which suspend fetching
    * @param completionHandler handler called on operation completed
    * @return  current KafkaConsumer instance
@@ -371,7 +419,15 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
 
   /**
    * Overrides the fetch offsets that the consumer will use on the next poll.
-   *
+   * <p>
+   * Due to internal buffering of messages,
+   * the {@linkplain #handler(Handler) record handler} will 
+   * continue to observe messages fetched with respect to the old offset  
+   * until some time <em>after</em> the given {@code completionHandler} 
+   * is called. In contrast, the once the given {@code completionHandler} 
+   * is called the {@link #batchHandler(Handler)} will only see messages 
+   * consistent with the new offset.
+   * 
    * @param topicPartition  topic partition for which seek
    * @param offset  offset to seek inside the topic partition
    * @param completionHandler handler called on operation completed
@@ -400,7 +456,15 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
 
   /**
    * Seek to the first offset for each of the given partition.
-   *
+   * <p>
+   * Due to internal buffering of messages,
+   * the {@linkplain #handler(Handler) record handler} will 
+   * continue to observe messages fetched with respect to the old offset  
+   * until some time <em>after</em> the given {@code completionHandler} 
+   * is called. In contrast, the once the given {@code completionHandler} 
+   * is called the {@link #batchHandler(Handler)} will only see messages 
+   * consistent with the new offset.
+   * 
    * @param topicPartition topic partition for which seek
    * @param completionHandler handler called on operation completed
    * @return  current KafkaConsumer instance
@@ -410,7 +474,15 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
 
   /**
    * Seek to the first offset for each of the given partitions.
-   *
+   * <p>
+   * Due to internal buffering of messages,
+   * the {@linkplain #handler(Handler) record handler} will 
+   * continue to observe messages fetched with respect to the old offset  
+   * until some time <em>after</em> the given {@code completionHandler} 
+   * is called. In contrast, the once the given {@code completionHandler} 
+   * is called the {@link #batchHandler(Handler)} will only see messages 
+   * consistent with the new offset.
+   * 
    * @param topicPartitions topic partition for which seek
    * @param completionHandler handler called on operation completed
    * @return  current KafkaConsumer instance
@@ -438,7 +510,15 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
 
   /**
    * Seek to the last offset for each of the given partition.
-   *
+   * <p>
+   * Due to internal buffering of messages,
+   * the {@linkplain #handler(Handler) record handler} will 
+   * continue to observe messages fetched with respect to the old offset  
+   * until some time <em>after</em> the given {@code completionHandler} 
+   * is called. In contrast, the once the given {@code completionHandler} 
+   * is called the {@link #batchHandler(Handler)} will only see messages 
+   * consistent with the new offset.
+   * 
    * @param topicPartition topic partition for which seek
    * @param completionHandler handler called on operation completed
    * @return  current KafkaConsumer instance
@@ -448,7 +528,15 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
 
   /**
    * Seek to the last offset for each of the given partitions.
-   *
+   * <p>
+   * Due to internal buffering of messages,
+   * the {@linkplain #handler(Handler) record handler} will 
+   * continue to observe messages fetched with respect to the old offset  
+   * until some time <em>after</em> the given {@code completionHandler} 
+   * is called. In contrast, the once the given {@code completionHandler} 
+   * is called the {@link #batchHandler(Handler)} will only see messages 
+   * consistent with the new offset.
+   * 
    * @param topicPartitions topic partition for which seek
    * @param completionHandler handler called on operation completed
    * @return  current KafkaConsumer instance

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
@@ -128,7 +128,15 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
 
   /**
    * Suspend fetching from the requested partitions.
-   *
+   * <p>
+   * Due to internal buffering of messages,
+   * the {@linkplain #handler(Handler) record handler} will 
+   * continue to observe messages from the given {@code topicParations} 
+   * until some time <em>after</em> the given {@code completionHandler} 
+   * is called. In contrast, the once the given {@code completionHandler} 
+   * is called the {@link #batchHandler(Handler)} will not see messages 
+   * from the given {@code topicParations}.
+   * 
    * @param topicPartitions topic partition from which suspend fetching
    * @param completionHandler handler called on operation completed
    * @return  current KafkaReadStream instance
@@ -152,7 +160,7 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
 
   /**
    * Resume specified partitions which have been paused with pause.
-   *
+   * 
    * @param topicPartitions topic partition from which resume fetching
    * @param completionHandler handler called on operation completed
    * @return  current KafkaReadStream instance
@@ -169,6 +177,14 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
 
   /**
    * Seek to the last offset for each of the given partitions.
+   * <p>
+   * Due to internal buffering of messages,
+   * the {@linkplain #handler(Handler) record handler} will 
+   * continue to observe messages fetched with respect to the old offset  
+   * until some time <em>after</em> the given {@code completionHandler} 
+   * is called. In contrast, the once the given {@code completionHandler} 
+   * is called the {@link #batchHandler(Handler)} will only see messages 
+   * consistent with the new offset.
    *
    * @param topicPartitions topic partition for which seek
    * @param completionHandler handler called on operation completed
@@ -186,6 +202,14 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
 
   /**
    * Seek to the first offset for each of the given partitions.
+   * <p>
+   * Due to internal buffering of messages,
+   * the {@linkplain #handler(Handler) record handler} will 
+   * continue to observe messages fetched with respect to the old offset  
+   * until some time <em>after</em> the given {@code completionHandler} 
+   * is called. In contrast, the once the given {@code completionHandler} 
+   * is called the {@link #batchHandler(Handler)} will only see messages 
+   * consistent with the new offset.
    *
    * @param topicPartitions topic partition for which seek
    * @param completionHandler handler called on operation completed
@@ -204,6 +228,14 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
 
   /**
    * Overrides the fetch offsets that the consumer will use on the next poll.
+   * <p>
+   * Due to internal buffering of messages,
+   * the {@linkplain #handler(Handler) record handler} will 
+   * continue to observe messages fetched with respect to the old offset  
+   * until some time <em>after</em> the given {@code completionHandler} 
+   * is called. In contrast, the once the given {@code completionHandler} 
+   * is called the {@link #batchHandler(Handler)} will only see messages 
+   * consistent with the new offset.
    *
    * @param topicPartition  topic partition for which seek
    * @param offset  offset to seek inside the topic partition
@@ -238,6 +270,14 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
 
   /**
    * Subscribe to the given list of topics to get dynamically assigned partitions.
+   * <p>
+   * Due to internal buffering of messages, when changing the subscribed topics  
+   * the old set of topics may remain in effect 
+   * (as observed by the {@linkplain #handler(Handler)} record handler}) 
+   * until some time <em>after</em> the given {@code completionHandler} 
+   * is called. In contrast, the once the given {@code completionHandler} 
+   * is called the {@link #batchHandler(Handler)} will only see messages 
+   * consistent with the new set of topics.
    *
    * @param topics  topics to subscribe to
    * @param completionHandler handler called on operation completed
@@ -269,7 +309,7 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
   KafkaReadStream<K, V> subscription(Handler<AsyncResult<Set<String>>> handler);
 
   /**
-   * Manually assign a list of partition to this consumer.
+   * Manually assign a set of partitions to this consumer.
    *
    * @param partitions  partitions which want assigned
    * @return  current KafkaReadStream instance
@@ -277,7 +317,15 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
   KafkaReadStream<K, V> assign(Set<TopicPartition> partitions);
 
   /**
-   * Manually assign a list of partition to this consumer.
+   * Manually assign a set of partitions to this consumer.
+   * <p>
+   * Due to internal buffering of messages, when reassigning
+   * the old set of partitions may remain in effect 
+   * (as observed by the {@linkplain #handler(Handler)} record handler)} 
+   * until some time <em>after</em> the given {@code completionHandler} 
+   * is called. In contrast, the once the given {@code completionHandler} 
+   * is called the {@link #batchHandler(Handler)} will only see messages 
+   * consistent with the new set of partitions.
    *
    * @param partitions  partitions which want assigned
    * @param completionHandler handler called on operation completed

--- a/src/main/java/io/vertx/kafka/client/package-info.java
+++ b/src/main/java/io/vertx/kafka/client/package-info.java
@@ -180,6 +180,16 @@
  * Calling {@link io.vertx.kafka.client.consumer.KafkaConsumer#assignment(io.vertx.core.Handler)} provides
  * the list of the current assigned partitions.
  *
+ * == Changing the subscription or assignment
+ * 
+ * You can change the subscribed topics, or assigned partitions after you have started to consume messages, simply 
+ * by calling `subscribe()` or `assign()` again. 
+ * 
+ * Note that due to internal buffering of messages it is possible that the record handler will continue to 
+ * observe messages from the old subscription or assignment _after_ the `subscribe()` or `assign()` 
+ * method's completion handler has been called. This is not the case for messages observed by the batch handler: 
+ * Once the completion handler has been called it will only observe messages read from the subscription or assignment.
+ *
  * == Getting topic partition information
  *
  * You can call the {@link io.vertx.kafka.client.consumer.KafkaConsumer#partitionsFor} to get information about
@@ -242,6 +252,11 @@
  * {@link examples.VertxKafkaClientExamples#exampleSeekToEnd}
  * ----
  *
+ * Note that due to internal buffering of messages it is possible that the record handler will continue to 
+ * observe messages read from the original offset for a time _after_ the `seek*()` method's completion 
+ * handler has been called. This is not the case for messages observed by the batch handler: Once the
+ * `seek*()` completion handler has been called it will only observe messages read from the new offset.
+ *
  * == Offset lookup
  *
  * You can use the beginningOffsets API introduced in Kafka 0.10.1.1 to get the first offset
@@ -277,7 +292,13 @@
  * to continue message processing.
  *
  * To achieve that you can use {@link io.vertx.kafka.client.consumer.KafkaConsumer#pause} and
- * {@link io.vertx.kafka.client.consumer.KafkaConsumer#resume}
+ * {@link io.vertx.kafka.client.consumer.KafkaConsumer#resume}.
+ * 
+ * In the case of the partition-specific pause and resume it is possible that the record handler will continue to 
+ * observe messages from a paused partition for a time _after_ the `pause()` method's completion 
+ * handler has been called. This is not the case for messages observed by the batch handler: Once the
+ * `pause()` completion handler has been called it will only observe messages from those partitions which 
+ * rare not paused.
  *
  * [source,$lang]
  * ----


### PR DESCRIPTION
This PR fixes #48, per IRC conversation with @vietj, namely:

* Document the existing semantics about what's observable from the record handler following execution of the completion handler of assign() ,subscribe() ,seek(), pause() etc.
* Add tests that the batch handler does not have the same semantics.