### PR TITLE
Generify return type of KafkaConsumerRecord.record()

### DIFF
--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumerRecord.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumerRecord.java
@@ -71,5 +71,5 @@ public interface KafkaConsumerRecord<K, V> {
    * @return  the native Kafka consumer record with backed information
    */
   @GenIgnore
-  ConsumerRecord record();
+  ConsumerRecord<K, V> record();
 }


### PR DESCRIPTION
There's no obvious reason why it was raw.