### PR TITLE
Fixes #73: vertx shutdown fails if an unassigned consumer is present

### DIFF
--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
@@ -112,13 +112,13 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
       if (handler != null) {
         future = Future.future();
         future.setHandler(event-> {
-          // When we've executed the task on the worker thread, 
+          // When we've executed the task on the worker thread,
           // run the callback on the eventloop thread
           this.context.runOnContext(v-> {
             handler.handle(event);
             });
           });
-        
+
       } else {
         future = null;
       }
@@ -149,7 +149,7 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
   }
 
   private void schedule(long delay) {
-    if (this.consuming.get() 
+    if (this.consuming.get()
         && !this.paused.get()
         && this.recordHandler != null) {
 
@@ -529,7 +529,6 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
 
   @Override
   public void close(Handler<AsyncResult<Void>> completionHandler) {
-
     if (this.closed.compareAndSet(false, true)) {
       this.worker.submit(() -> {
         this.consumer.close();
@@ -541,6 +540,11 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
         });
       });
       this.consumer.wakeup();
+    }
+    else {
+      if (completionHandler != null) {
+        completionHandler.handle(Future.succeededFuture());
+      }
     }
   }
 


### PR DESCRIPTION
PR consists of two commits:
1. Test case to reproduce the isse
2. Fix: introduces a minimal change to ```KafkaReadStreamImpl.close```: the completionHandler is now also 
called when the consumer is in closed state. This makes sure that the close() call also returns in that case

BR, Tim