### PR TITLE
Make the polling timeout configurable. Still defaults to 1000 ms.

### DIFF
--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
@@ -502,10 +502,10 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
    */
   @Fluent
   KafkaConsumer<K, V> partitionsFor(String topic, Handler<AsyncResult<List<PartitionInfo>>> handler);
-  
+
   /**
-   * Set the handler to be used when batches of messages are fetched 
-   * from the Kafka server. Batch handlers need to take care not to block 
+   * Set the handler to be used when batches of messages are fetched
+   * from the Kafka server. Batch handlers need to take care not to block
    * the event loop when dealing with large batches. It is better to process
    * records individually using the {@link #handler(Handler) record handler}.
    * @param handler handler called when batches of messages are fetched
@@ -597,4 +597,16 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
    */
   @GenIgnore
   Consumer<K, V> unwrap();
+
+  /**
+   * Sets the polling timeout (in ms) for the underlying native Kafka Consumer. Defaults to 1000.
+   * Setting timeout to a lower value results in a more 'responsive' client, because it will block for a shorter period
+   * if no data is available in the assigned partition and therefore allows subsequent actions to be executed with a shorter
+   * delay. At the same time, the client will poll more frequently and thus will potentially create a higher load on the Kafka Broker.
+   *
+   * @param timeout The time, in milliseconds, spent waiting in poll if data is not available in the buffer.
+   * If 0, returns immediately with any records that are available currently in the native Kafka consumer's buffer,
+   * else returns empty. Must not be negative.
+   */
+  KafkaConsumer<K, V> pollingTimeout(long timeout);
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
@@ -599,7 +599,7 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
   Consumer<K, V> unwrap();
 
   /**
-   * Sets the polling timeout (in ms) for the underlying native Kafka Consumer. Defaults to 1000.
+   * Sets the poll timeout (in ms) for the underlying native Kafka Consumer. Defaults to 1000.
    * Setting timeout to a lower value results in a more 'responsive' client, because it will block for a shorter period
    * if no data is available in the assigned partition and therefore allows subsequent actions to be executed with a shorter
    * delay. At the same time, the client will poll more frequently and thus will potentially create a higher load on the Kafka Broker.
@@ -608,5 +608,5 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
    * If 0, returns immediately with any records that are available currently in the native Kafka consumer's buffer,
    * else returns empty. Must not be negative.
    */
-  KafkaConsumer<K, V> pollingTimeout(long timeout);
+  KafkaConsumer<K, V> pollTimeout(long timeout);
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
@@ -411,14 +411,25 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
   Consumer<K, V> unwrap();
 
   /**
-   * Set the handler that will be called when a new batch of records is 
-   * returned from Kafka. Batch handlers need to take care not to block 
+   * Set the handler that will be called when a new batch of records is
+   * returned from Kafka. Batch handlers need to take care not to block
    * the event loop when dealing with large batches. It is better to process
    * records individually using the {@link #handler(Handler) record handler}.
-   * 
+   *
    * @param handler handler called each time Kafka returns a batch of records.
    * @return current KafkaReadStream instance.
    */
   KafkaReadStream<K, V> batchHandler(Handler<ConsumerRecords<K, V>> handler);
 
+  /**
+   * Sets the polling timeout (in ms) for the underlying native Kafka Consumer. Defaults to 1000.
+   * Setting timeout to a lower value results in a more 'responsive' client, because it will block for a shorter period
+   * if no data is available in the assigned partition and therefore allows subsequent actions to be executed with a shorter
+   * delay. At the same time, the client will poll more frequently and thus will potentially create a higher load on the Kafka Broker.
+   *
+   * @param timeout The time, in milliseconds, spent waiting in poll if data is not available in the buffer.
+   * If 0, returns immediately with any records that are available currently in the native Kafka consumer's buffer,
+   * else returns empty. Must not be negative.
+   */
+  void pollingTimeout(long timeout);
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
@@ -422,7 +422,7 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
   KafkaReadStream<K, V> batchHandler(Handler<ConsumerRecords<K, V>> handler);
 
   /**
-   * Sets the polling timeout (in ms) for the underlying native Kafka Consumer. Defaults to 1000.
+   * Sets the poll timeout (in ms) for the underlying native Kafka Consumer. Defaults to 1000.
    * Setting timeout to a lower value results in a more 'responsive' client, because it will block for a shorter period
    * if no data is available in the assigned partition and therefore allows subsequent actions to be executed with a shorter
    * delay. At the same time, the client will poll more frequently and thus will potentially create a higher load on the Kafka Broker.
@@ -431,5 +431,5 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
    * If 0, returns immediately with any records that are available currently in the native Kafka consumer's buffer,
    * else returns empty. Must not be negative.
    */
-  void pollingTimeout(long timeout);
+  void pollTimeout(long timeout);
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
@@ -431,5 +431,5 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
    * If 0, returns immediately with any records that are available currently in the native Kafka consumer's buffer,
    * else returns empty. Must not be negative.
    */
-  void pollTimeout(long timeout);
+  KafkaReadStreamImpl<K, V> pollTimeout(long timeout);
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
@@ -431,5 +431,5 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
    * If 0, returns immediately with any records that are available currently in the native Kafka consumer's buffer,
    * else returns empty. Must not be negative.
    */
-  KafkaReadStreamImpl<K, V> pollTimeout(long timeout);
+  KafkaReadStream<K, V> pollTimeout(long timeout);
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
@@ -529,8 +529,8 @@ public class KafkaConsumerImpl<K, V> implements KafkaConsumer<K, V> {
   }
 
   @Override
-  public KafkaConsumer<K, V> pollingTimeout(long timeout) {
-    this.stream.pollingTimeout(timeout);
+  public KafkaConsumer<K, V> pollTimeout(long timeout) {
+    this.stream.pollTimeout(timeout);
     return this;
   }
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
@@ -527,4 +527,10 @@ public class KafkaConsumerImpl<K, V> implements KafkaConsumer<K, V> {
     });
     return this;
   }
+
+  @Override
+  public KafkaConsumer<K, V> pollingTimeout(long timeout) {
+    this.stream.pollingTimeout(timeout);
+    return this;
+  }
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
@@ -65,7 +65,7 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
   private Handler<ConsumerRecords<K, V>> batchHandler;
   private Handler<Set<TopicPartition>> partitionsRevokedHandler;
   private Handler<Set<TopicPartition>> partitionsAssignedHandler;
-  private long pollingTimeout = 1000L;
+  private long pollTimeout = 1000L;
 
   private ExecutorService worker;
 
@@ -137,7 +137,7 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
     this.worker.submit(() -> {
       if (!this.closed.get()) {
         try {
-          ConsumerRecords<K, V> records = this.consumer.poll(pollingTimeout);
+          ConsumerRecords<K, V> records = this.consumer.poll(pollTimeout);
           if (records != null && records.count() > 0) {
             this.context.runOnContext(v -> handler.handle(records));
           } else {
@@ -654,6 +654,6 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
 
   @Override
   public void pollTimeout(long timeout) {
-    this.pollingTimeout = timeout;
+    this.pollTimeout = timeout;
   }
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
@@ -653,7 +653,7 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
   }
 
   @Override
-  public void pollingTimeout(long timeout) {
+  public void pollTimeout(long timeout) {
     this.pollingTimeout = timeout;
   }
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
@@ -65,6 +65,7 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
   private Handler<ConsumerRecords<K, V>> batchHandler;
   private Handler<Set<TopicPartition>> partitionsRevokedHandler;
   private Handler<Set<TopicPartition>> partitionsAssignedHandler;
+  private long pollingTimeout = 1000L;
 
   private ExecutorService worker;
 
@@ -136,7 +137,7 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
     this.worker.submit(() -> {
       if (!this.closed.get()) {
         try {
-          ConsumerRecords<K, V> records = this.consumer.poll(1000);
+          ConsumerRecords<K, V> records = this.consumer.poll(pollingTimeout);
           if (records != null && records.count() > 0) {
             this.context.runOnContext(v -> handler.handle(records));
           } else {
@@ -649,5 +650,10 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
   public KafkaReadStream batchHandler(Handler<ConsumerRecords<K, V>> handler) {
     this.batchHandler = handler;
     return this;
+  }
+
+  @Override
+  public void pollingTimeout(long timeout) {
+    this.pollingTimeout = timeout;
   }
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
@@ -653,7 +653,7 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
   }
 
   @Override
-  public KafkaReadStreamImpl<K, V> pollTimeout(long timeout) {
+  public KafkaReadStream<K, V> pollTimeout(long timeout) {
     this.pollTimeout = timeout;
     return this;
   }

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
@@ -653,7 +653,8 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
   }
 
   @Override
-  public void pollTimeout(long timeout) {
+  public KafkaReadStreamImpl<K, V> pollTimeout(long timeout) {
     this.pollTimeout = timeout;
+    return this;
   }
 }

--- a/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
@@ -993,6 +993,33 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
     consumer.subscribe(Collections.singleton("someTopic")).handler(System.out::println);
   }
 
+  @Test
+  public void testPollingTimeout(TestContext ctx) throws Exception {
+    Async async = ctx.async();
+    String topicName = "testPollingTimeout";
+    Properties config = kafkaCluster.useTo().getConsumerProperties(topicName, topicName, OffsetResetStrategy.EARLIEST);
+    config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+    io.vertx.kafka.client.common.TopicPartition topicPartition = new io.vertx.kafka.client.common.TopicPartition(topicName, 0);
+    KafkaConsumer<Object, Object> consumerWithCustomTimeout = KafkaConsumer.create(vertx, config);
+
+    int pollingTimeout = 1500;
+    // Set the polling timeout to 1500 ms (default is 1000)
+    consumerWithCustomTimeout.pollingTimeout(pollingTimeout);
+    // Subscribe to the empty topic (we want the poll() call to timeout!)
+    consumerWithCustomTimeout.subscribe(topicName, subscribeRes -> {
+      consumerWithCustomTimeout.handler(rec -> {}); // Consumer will now immediately poll once
+      long beforeSeek = System.currentTimeMillis();
+      consumerWithCustomTimeout.seekToBeginning(topicPartition, seekRes -> {
+        long durationWShortTimeout = System.currentTimeMillis() - beforeSeek;
+        ctx.assertTrue(durationWShortTimeout >= pollingTimeout, "Operation must take at least as long as the polling timeout");
+        consumerWithCustomTimeout.close();
+        async.countDown();
+      });
+    });
+  }
+
   <K, V> KafkaReadStream<K, V> createConsumer(Context context, Properties config) throws Exception {
     CompletableFuture<KafkaReadStream<K, V>> ret = new CompletableFuture<>();
     context.runOnContext(v -> {

--- a/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
@@ -994,9 +994,9 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
   }
 
   @Test
-  public void testPollingTimeout(TestContext ctx) throws Exception {
+  public void testPollTimeout(TestContext ctx) throws Exception {
     Async async = ctx.async();
-    String topicName = "testPollingTimeout";
+    String topicName = "testPollTimeout";
     Properties config = kafkaCluster.useTo().getConsumerProperties(topicName, topicName, OffsetResetStrategy.EARLIEST);
     config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
     config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
@@ -1006,7 +1006,7 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
 
     int pollingTimeout = 1500;
     // Set the polling timeout to 1500 ms (default is 1000)
-    consumerWithCustomTimeout.pollingTimeout(pollingTimeout);
+    consumerWithCustomTimeout.pollTimeout(pollingTimeout);
     // Subscribe to the empty topic (we want the poll() call to timeout!)
     consumerWithCustomTimeout.subscribe(topicName, subscribeRes -> {
       consumerWithCustomTimeout.handler(rec -> {}); // Consumer will now immediately poll once


### PR DESCRIPTION
Hi, @vietj 

As just discussed, here's a PR that makes the polling timeout configurable. Default timeout remains at 1000 ms, so that change is backwards-compatible.

I haven't included a test yet (the change is not really complex, but hard to test because the exact timing is unpredictable). What I have implemented to check if the polling timeout has an effect is the following test:
Should I also commit it? ;)

```
  @Test
  public void testPollingTimeout(TestContext ctx) throws Exception {
    Async async = ctx.async();
    String topicName = "testPollingTimeout";
    Properties config = kafkaCluster.useTo().getConsumerProperties(topicName, topicName, OffsetResetStrategy.EARLIEST);
    config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
    config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);

    io.vertx.kafka.client.common.TopicPartition topicPartition = new io.vertx.kafka.client.common.TopicPartition(topicName, 0);
    KafkaConsumer<Object, Object> timeoutConsumer = KafkaConsumer.create(vertx, config);
    timeoutConsumer.handler(rec -> {});

    // Subscribe to empty topic (we want the poll() call to timeout!)
    timeoutConsumer.subscribe(topicName, subscribeRes -> {
      long beforeSeek = System.currentTimeMillis();
      timeoutConsumer.seekToBeginning(topicPartition, seekRes -> {
        long durationWDefaultTimeout = System.currentTimeMillis() - beforeSeek;

        long beforeSeekShortTimeout = System.currentTimeMillis();
        // Now reduce the polling timeout
        timeoutConsumer.pollingTimeout(1);
        timeoutConsumer.seekToBeginning(topicPartition, seekRes2 -> {
          long durationWShortTimeout =  System.currentTimeMillis() - beforeSeekShortTimeout;

          ctx.assertTrue(durationWDefaultTimeout > durationWShortTimeout,
            "Operation must be faster with shorter polling timeout than with default timeout.");

          timeoutConsumer.close();
          async.complete();
        });
      });
    });
  }
``` 