### PR TITLE
Updating to Apache Kafka 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
 
   <properties>
     <stack.version>3.5.1-SNAPSHOT</stack.version>
-    <kafka.version>0.11.0.1</kafka.version>
-    <debezium.version>0.6.1</debezium.version>
+    <kafka.version>1.0.0</kafka.version>
+    <debezium.version>0.7.1</debezium.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
POC for Kafka 1.0.0 (and DBZ 0.7.1)

One test failed (changed) due to changes on their error msgs, see their commit change on the `AdminUtils.scala` file.

See:
* https://github.com/apache/kafka/commit/5f6393f9b17cce17ded7a00e439599dfa77deb2d

Besides that, I've added a test for topic creation w/ 0 replicas. 


