### PR TITLE
Adding topic method as alternative for subscribe

### DIFF
--- a/src/main/generated/io/vertx/kafka/client/common/PartitionInfoConverter.java
+++ b/src/main/generated/io/vertx/kafka/client/common/PartitionInfoConverter.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2014 Red Hat, Inc. and others
- *
- * Red Hat licenses this file to you under the Apache License, version 2.0
- * (the "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at:
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
 package io.vertx.kafka.client.common;
 
 import io.vertx.core.json.JsonObject;
@@ -21,40 +5,57 @@ import io.vertx.core.json.JsonArray;
 
 /**
  * Converter for {@link io.vertx.kafka.client.common.PartitionInfo}.
- *
- * NOTE: This class has been automatically generated from the {@link io.vertx.kafka.client.common.PartitionInfo} original class using Vert.x codegen.
+ * NOTE: This class has been automatically generated from the {@link "io.vertx.kafka.client.common.PartitionInfo} original class using Vert.x codegen.
  */
 public class PartitionInfoConverter {
 
-  public static void fromJson(JsonObject json, PartitionInfo obj) {
-    if (json.getValue("inSyncReplicas") instanceof JsonArray) {
-      java.util.ArrayList<io.vertx.kafka.client.common.Node> list = new java.util.ArrayList<>();
-      json.getJsonArray("inSyncReplicas").forEach( item -> {
-        if (item instanceof JsonObject)
-          list.add(new io.vertx.kafka.client.common.Node((JsonObject)item));
-      });
-      obj.setInSyncReplicas(list);
-    }
-    if (json.getValue("leader") instanceof JsonObject) {
-      obj.setLeader(new io.vertx.kafka.client.common.Node((JsonObject)json.getValue("leader")));
-    }
-    if (json.getValue("partition") instanceof Number) {
-      obj.setPartition(((Number)json.getValue("partition")).intValue());
-    }
-    if (json.getValue("replicas") instanceof JsonArray) {
-      java.util.ArrayList<io.vertx.kafka.client.common.Node> list = new java.util.ArrayList<>();
-      json.getJsonArray("replicas").forEach( item -> {
-        if (item instanceof JsonObject)
-          list.add(new io.vertx.kafka.client.common.Node((JsonObject)item));
-      });
-      obj.setReplicas(list);
-    }
-    if (json.getValue("topic") instanceof String) {
-      obj.setTopic((String)json.getValue("topic"));
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, PartitionInfo obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "inSyncReplicas":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<io.vertx.kafka.client.common.Node> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof JsonObject)
+                list.add(new io.vertx.kafka.client.common.Node((JsonObject)item));
+            });
+            obj.setInSyncReplicas(list);
+          }
+          break;
+        case "leader":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setLeader(new io.vertx.kafka.client.common.Node((JsonObject)member.getValue()));
+          }
+          break;
+        case "partition":
+          if (member.getValue() instanceof Number) {
+            obj.setPartition(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "replicas":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<io.vertx.kafka.client.common.Node> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof JsonObject)
+                list.add(new io.vertx.kafka.client.common.Node((JsonObject)item));
+            });
+            obj.setReplicas(list);
+          }
+          break;
+        case "topic":
+          if (member.getValue() instanceof String) {
+            obj.setTopic((String)member.getValue());
+          }
+          break;
+      }
     }
   }
 
   public static void toJson(PartitionInfo obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(PartitionInfo obj, java.util.Map<String, Object> json) {
     if (obj.getInSyncReplicas() != null) {
       JsonArray array = new JsonArray();
       obj.getInSyncReplicas().forEach(item -> array.add(item.toJson()));

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
@@ -144,6 +144,60 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
    * @return  current KafkaConsumer instance
    */
   @Fluent
+  KafkaConsumer<K, V> topic(String topic);
+
+  /**
+   * Subscribe to the given list of topics to get dynamically assigned partitions.
+   *
+   * @param topics  topics to subscribe to
+   * @return  current KafkaConsumer instance
+   */
+  @Fluent
+  KafkaConsumer<K, V> topic(Set<String> topics);
+
+  /**
+   * Subscribe to the given topic to get dynamically assigned partitions.
+   * <p>
+   * Due to internal buffering of messages, when changing the subscribed topic
+   * the old topic may remain in effect
+   * (as observed by the {@linkplain #handler(Handler)} record handler})
+   * until some time <em>after</em> the given {@code completionHandler}
+   * is called. In contrast, the once the given {@code completionHandler}
+   * is called the {@link #batchHandler(Handler)} will only see messages
+   * consistent with the new topic.
+   *
+   * @param topic  topic to subscribe to
+   * @param completionHandler handler called on operation completed
+   * @return  current KafkaConsumer instance
+   */
+  @Fluent
+  KafkaConsumer<K, V> topic(String topic, Handler<AsyncResult<Void>> completionHandler);
+
+  /**
+   * Subscribe to the given list of topics to get dynamically assigned partitions.
+   * <p>
+   * Due to internal buffering of messages, when changing the subscribed topics
+   * the old set of topics may remain in effect
+   * (as observed by the {@linkplain #handler(Handler)} record handler})
+   * until some time <em>after</em> the given {@code completionHandler}
+   * is called. In contrast, the once the given {@code completionHandler}
+   * is called the {@link #batchHandler(Handler)} will only see messages
+   * consistent with the new set of topics.
+   *
+   * @param topics  topics to subscribe to
+   * @param completionHandler handler called on operation completed
+   * @return  current KafkaConsumer instance
+   */
+  @Fluent
+  KafkaConsumer<K, V> topic(Set<String> topics, Handler<AsyncResult<Void>> completionHandler);
+
+  /**
+   * Subscribe to the given topic to get dynamically assigned partitions.
+   *
+   * @param topic  topic to subscribe to
+   * @return  current KafkaConsumer instance
+   */
+  @Fluent
   KafkaConsumer<K, V> subscribe(String topic);
 
   /**

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
@@ -150,6 +150,27 @@ public class KafkaConsumerImpl<K, V> implements KafkaConsumer<K, V> {
   }
 
   @Override
+  public KafkaConsumer<K, V> topic(String topic) {
+    return this.topic(Collections.singleton(topic));
+  }
+
+  @Override
+  public KafkaConsumer<K, V> topic(Set<String> topics) {
+    return this.topic(topics, null);
+  }
+
+  @Override
+  public KafkaConsumer<K, V> topic(String topic, Handler<AsyncResult<Void>> completionHandler) {
+    return this.topic(Collections.singleton(topic), completionHandler);
+  }
+
+  @Override
+  public KafkaConsumer<K, V> topic(Set<String> topics, Handler<AsyncResult<Void>> completionHandler) {
+    this.stream.subscribe(topics, completionHandler);
+    return this;
+  }
+
+  @Override
   public KafkaConsumer<K, V> subscribe(String topic) {
     return this.subscribe(Collections.singleton(topic));
   }


### PR DESCRIPTION
After a quick chat with @cescoffier we figured the `subscribe` method of the consumer is very confusing in the Rx Java land.

See here, this code contains two different `subscribes`:
```java
KafkaConsumer.<String, String>create(vertx, config)
    .subscribe("foo") // Kafka topic subscribe
    .toFlowable()
        .subscribe(data -> {  // Subscribes to a Publisher
            System.out.println("We got: " + data.value());
         });
```

Or slightly different:

```java
Flowable<KafkaConsumerRecord> stream = KafkaConsumer.<String, String>create(vertx, config)
    .subscribe("foo") // Kafka topic subscribe
    .toFlowable();

stream.subscribe(data -> {  // Subscribes to a Publisher 
    System.out.println("We got: " + data.value());
});
```

I am proposing the introduction of the `topic` it would be likely more straightforward and fluent, see:

```java
KafkaConsumer.<String, String>create(vertx, config)
    .topic("foo") // Kafka topic subscribe
    .toFlowable()
        .subscribe(data -> {  // Subscribes to a Publisher
            System.out.println("We got: " + data.value());
         });

```

This proposal might have a few issues/thoguths:
* Should we deprecate the `subscribe`? 
  * Perhaps not, since the non Rx world would perhaps be just fine w/ the `subscribe`
* does this make sense for `3.6.0` or already for `3.5.x` ? 

Any comments @vietj ? 
