### PR TITLE
Make kafka headers actually usable and tested

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   <properties>
     <stack.version>3.6.0-SNAPSHOT</stack.version>
     <kafka.version>1.0.0</kafka.version>
-    <debezium.version>0.7.3</debezium.version>
+    <debezium.version>0.7.5</debezium.version>
   </properties>
 
   <dependencyManagement>

--- a/src/main/generated/io/vertx/kafka/client/common/PartitionInfoConverter.java
+++ b/src/main/generated/io/vertx/kafka/client/common/PartitionInfoConverter.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2014 Red Hat, Inc. and others
- *
- * Red Hat licenses this file to you under the Apache License, version 2.0
- * (the "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at:
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
 package io.vertx.kafka.client.common;
 
 import io.vertx.core.json.JsonObject;
@@ -21,40 +5,57 @@ import io.vertx.core.json.JsonArray;
 
 /**
  * Converter for {@link io.vertx.kafka.client.common.PartitionInfo}.
- *
- * NOTE: This class has been automatically generated from the {@link io.vertx.kafka.client.common.PartitionInfo} original class using Vert.x codegen.
+ * NOTE: This class has been automatically generated from the {@link "io.vertx.kafka.client.common.PartitionInfo} original class using Vert.x codegen.
  */
 public class PartitionInfoConverter {
 
-  public static void fromJson(JsonObject json, PartitionInfo obj) {
-    if (json.getValue("inSyncReplicas") instanceof JsonArray) {
-      java.util.ArrayList<io.vertx.kafka.client.common.Node> list = new java.util.ArrayList<>();
-      json.getJsonArray("inSyncReplicas").forEach( item -> {
-        if (item instanceof JsonObject)
-          list.add(new io.vertx.kafka.client.common.Node((JsonObject)item));
-      });
-      obj.setInSyncReplicas(list);
-    }
-    if (json.getValue("leader") instanceof JsonObject) {
-      obj.setLeader(new io.vertx.kafka.client.common.Node((JsonObject)json.getValue("leader")));
-    }
-    if (json.getValue("partition") instanceof Number) {
-      obj.setPartition(((Number)json.getValue("partition")).intValue());
-    }
-    if (json.getValue("replicas") instanceof JsonArray) {
-      java.util.ArrayList<io.vertx.kafka.client.common.Node> list = new java.util.ArrayList<>();
-      json.getJsonArray("replicas").forEach( item -> {
-        if (item instanceof JsonObject)
-          list.add(new io.vertx.kafka.client.common.Node((JsonObject)item));
-      });
-      obj.setReplicas(list);
-    }
-    if (json.getValue("topic") instanceof String) {
-      obj.setTopic((String)json.getValue("topic"));
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, PartitionInfo obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "inSyncReplicas":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<io.vertx.kafka.client.common.Node> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof JsonObject)
+                list.add(new io.vertx.kafka.client.common.Node((JsonObject)item));
+            });
+            obj.setInSyncReplicas(list);
+          }
+          break;
+        case "leader":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setLeader(new io.vertx.kafka.client.common.Node((JsonObject)member.getValue()));
+          }
+          break;
+        case "partition":
+          if (member.getValue() instanceof Number) {
+            obj.setPartition(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "replicas":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<io.vertx.kafka.client.common.Node> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof JsonObject)
+                list.add(new io.vertx.kafka.client.common.Node((JsonObject)item));
+            });
+            obj.setReplicas(list);
+          }
+          break;
+        case "topic":
+          if (member.getValue() instanceof String) {
+            obj.setTopic((String)member.getValue());
+          }
+          break;
+      }
     }
   }
 
   public static void toJson(PartitionInfo obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(PartitionInfo obj, java.util.Map<String, Object> json) {
     if (obj.getInSyncReplicas() != null) {
       JsonArray array = new JsonArray();
       obj.getInSyncReplicas().forEach(item -> array.add(item.toJson()));

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumerRecord.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumerRecord.java
@@ -18,8 +18,11 @@ package io.vertx.kafka.client.consumer;
 
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.kafka.client.producer.KafkaHeader;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.record.TimestampType;
+
+import java.util.List;
 
 /**
  * Vert.x Kafka consumer record
@@ -66,6 +69,11 @@ public interface KafkaConsumerRecord<K, V> {
    * @return  the value
    */
   V value();
+
+  /**
+   * @return the list of consumer record headers
+   */
+  List<KafkaHeader> headers();
 
   /**
    * @return  the native Kafka consumer record with backed information

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerRecordImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerRecordImpl.java
@@ -17,8 +17,14 @@
 package io.vertx.kafka.client.consumer.impl;
 
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.producer.KafkaHeader;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.record.TimestampType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Vert.x Kafka consumer record implementation
@@ -26,6 +32,7 @@ import org.apache.kafka.common.record.TimestampType;
 public class KafkaConsumerRecordImpl<K, V> implements KafkaConsumerRecord<K, V> {
 
   private final ConsumerRecord<K, V> record;
+  private List<KafkaHeader> headers;
 
   /**
    * Constructor
@@ -82,6 +89,21 @@ public class KafkaConsumerRecordImpl<K, V> implements KafkaConsumerRecord<K, V> 
   }
 
   @Override
+  public List<KafkaHeader> headers() {
+    if (headers == null) {
+      if (record.headers() == null) {
+        headers = Collections.emptyList();
+      } else {
+        headers = new ArrayList<>();
+        for (Header header : record.headers()) {
+          headers.add(KafkaHeader.header(header.key(), header.value()));
+        }
+      }
+    }
+    return headers;
+  }
+
+  @Override
   public String toString() {
 
     return "KafkaConsumerRecord{" +
@@ -91,6 +113,7 @@ public class KafkaConsumerRecordImpl<K, V> implements KafkaConsumerRecord<K, V> 
       ",timestamp=" + this.record.timestamp() +
       ",key=" + this.record.key() +
       ",value=" + this.record.value() +
+      ",headers=" + this.record.headers() +
       "}";
   }
 }

--- a/src/main/java/io/vertx/kafka/client/producer/KafkaHeader.java
+++ b/src/main/java/io/vertx/kafka/client/producer/KafkaHeader.java
@@ -16,7 +16,11 @@
 
 package io.vertx.kafka.client.producer;
 
+import io.vertx.codegen.annotations.CacheReturn;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.kafka.client.producer.impl.KafkaHeaderImpl;
 
 /**
  * Vert.x Kafka producer record header.
@@ -24,8 +28,29 @@ import io.vertx.codegen.annotations.VertxGen;
 @VertxGen
 public interface KafkaHeader {
 
+  static KafkaHeader header(String key, Buffer value) {
+    return new KafkaHeaderImpl(key, value);
+  }
+
+  static KafkaHeader header(String key, String value) {
+    return new KafkaHeaderImpl(key, value);
+  }
+
+  @GenIgnore
+  static KafkaHeader header(String key, byte[] value) {
+    return new KafkaHeaderImpl(key, Buffer.buffer(value));
+  }
+
+  /**
+   * @return the buffer key
+   */
+  @CacheReturn
   String key();
 
-  byte[] value();
+  /**
+   * @return the buffer value
+   */
+  @CacheReturn
+  Buffer value();
 
 }

--- a/src/main/java/io/vertx/kafka/client/producer/KafkaProducerRecord.java
+++ b/src/main/java/io/vertx/kafka/client/producer/KafkaProducerRecord.java
@@ -16,8 +16,11 @@
 
 package io.vertx.kafka.client.producer;
 
+import io.vertx.codegen.annotations.CacheReturn;
+import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.kafka.client.producer.impl.KafkaProducerRecordImpl;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
@@ -93,73 +96,6 @@ public interface KafkaProducerRecord<K, V> {
   }
 
   /**
-   * Create a concrete instance of a Vert.x producer record
-   *
-   * @param topic the topic this record is being sent to
-   * @param key the key (or null if no key is specified)
-   * @param value the value
-   * @param timestamp the timestamp of this record
-   * @param partition the partition to which the record will be sent (or null if no partition was specified)
-   * @param kafkaHeaders list of the {@link KafkaHeader}
-   * @param <K> key type
-   * @param <V> value type
-   * @return  Vert.x producer record
-   */
-  static <K, V> KafkaProducerRecord<K, V> create(String topic, K key, V value, Long timestamp, Integer partition, List<KafkaHeader> kafkaHeaders) {
-
-    return new KafkaProducerRecordImpl<>(topic, key, value, timestamp, partition, kafkaHeaders);
-  }
-
-  /**
-   * Create a concrete instance of a Vert.x producer record
-   *
-   * @param topic the topic this record is being sent to
-   * @param key the key (or null if no key is specified)
-   * @param value the value
-   * @param partition the partition to which the record will be sent (or null if no partition was specified)
-   * @param kafkaHeaders list of the {@link KafkaHeader}
-   * @param <K> key type
-   * @param <V> value type
-   * @return  Vert.x producer record
-   */
-  @GenIgnore
-  static <K, V> KafkaProducerRecord<K, V> create(String topic, K key, V value, Integer partition, List<KafkaHeader> kafkaHeaders) {
-
-    return new KafkaProducerRecordImpl<>(topic, key, value, partition, kafkaHeaders);
-  }
-
-  /**
-   * Create a concrete instance of a Vert.x producer record
-   *
-   * @param topic the topic this record is being sent to
-   * @param key the key (or null if no key is specified)
-   * @param value the value
-   * @param kafkaHeaders list of the {@link KafkaHeader}
-   * @param <K> key type
-   * @param <V> value type
-   * @return  Vert.x producer record
-   */
-  static <K, V> KafkaProducerRecord<K, V> create(String topic, K key, V value, List<KafkaHeader> kafkaHeaders) {
-
-    return new KafkaProducerRecordImpl<>(topic, key, value, kafkaHeaders);
-  }
-
-  /**
-   * Create a concrete instance of a Vert.x producer record
-   *
-   * @param topic the topic this record is being sent to
-   * @param value the value
-   * @param <K> key type
-   * @param <V> value type
-   * @param kafkaHeaders list of the {@link KafkaHeader}
-   * @return  Vert.x producer record
-   */
-  static <K, V> KafkaProducerRecord<K, V> create(String topic, V value, List<KafkaHeader> kafkaHeaders) {
-
-    return new KafkaProducerRecordImpl<>(topic, value, kafkaHeaders);
-  }
-
-  /**
    * @return  the topic this record is being sent to
    */
   String topic();
@@ -185,13 +121,45 @@ public interface KafkaProducerRecord<K, V> {
   Integer partition();
 
   /**
-   * @return  the native Kafka producer record with backed information
+   * Like {@link #addHeader(KafkaHeader)} but with a key/value pair
    */
-  @GenIgnore
-  ProducerRecord record();
+  @Fluent
+  KafkaProducerRecord<K, V> addHeader(String key, String value);
+
+  /**
+   * Like {@link #addHeader(KafkaHeader)} but with a key/value pair
+   */
+  @Fluent
+  KafkaProducerRecord<K, V> addHeader(String key, Buffer value);
+
+  /**
+   * Add an header to this record.
+   *
+   * @param header the header
+   * @return  current KafkaProducerRecord instance
+   */
+  @Fluent
+  KafkaProducerRecord<K, V> addHeader(KafkaHeader header);
+
+  /**
+   * Add a list of headers to this record.
+   *
+   * @param headers the headers
+   * @return  current KafkaProducerRecord instance
+   */
+  @Fluent
+  KafkaProducerRecord<K, V> addHeaders(List<KafkaHeader> headers);
 
   /**
    * @return  the headers of this record
    */
+  @CacheReturn
   List<KafkaHeader> headers();
+
+  /**
+   * @return a created native Kafka producer record with backed information
+   */
+  @GenIgnore
+  ProducerRecord record();
+
 }

--- a/src/main/java/io/vertx/kafka/client/producer/impl/KafkaHeaderImpl.java
+++ b/src/main/java/io/vertx/kafka/client/producer/impl/KafkaHeaderImpl.java
@@ -16,15 +16,8 @@
 
 package io.vertx.kafka.client.producer.impl;
 
+import io.vertx.core.buffer.Buffer;
 import io.vertx.kafka.client.producer.KafkaHeader;
-import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.common.header.internals.RecordHeader;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Vert.x Kafka producer record header implementation
@@ -32,15 +25,15 @@ import java.util.stream.Stream;
 public class KafkaHeaderImpl implements KafkaHeader {
 
   private String key;
-  private byte[] value;
+  private Buffer value;
 
-  public KafkaHeaderImpl(String key, byte[] value) {
+  public KafkaHeaderImpl(String key, Buffer value) {
     this.key = key;
     this.value = value;
   }
 
   public KafkaHeaderImpl(String key, String value) {
-    this(key, value.getBytes());
+    this(key, Buffer.buffer(value));
   }
 
   @Override
@@ -49,37 +42,8 @@ public class KafkaHeaderImpl implements KafkaHeader {
   }
 
   @Override
-  public byte[] value() {
+  public Buffer value() {
     return value;
   }
 
-  /**
-   * Convert {@link Headers} to a list of {@link KafkaHeader}
-   *
-   * @param headers Headers from the Apache Kafka Client
-   * @return a list of {@link KafkaHeader}
-   */
-  public static List<KafkaHeader> fromHeaders(Headers headers) {
-
-    if (headers == null || headers.toArray().length == 0) {
-      return Collections.emptyList();
-    }
-
-    return Stream.of(headers.toArray()).map(header -> new KafkaHeaderImpl(header.key(), header.value())).collect(Collectors.toList());
-  }
-
-  /**
-   * Convert a list of {@link KafkaHeader} to a list of {@link Header}
-   *
-   * @param kafkaHeaders list of {@link KafkaHeader}
-   * @return a list of {@link Header} from the Apache Kafka Client
-   */
-  public static List<Header> toHeaderList(List<KafkaHeader> kafkaHeaders) {
-
-    if (kafkaHeaders == null || kafkaHeaders.isEmpty()) {
-      return Collections.emptyList();
-    }
-
-    return kafkaHeaders.stream().map(kafkaHeader -> new RecordHeader(kafkaHeader.key(), kafkaHeader.value())).collect(Collectors.toList());
-  }
 }

--- a/src/test/java/io/vertx/kafka/client/tests/KafkaHeaderTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/KafkaHeaderTest.java
@@ -17,6 +17,7 @@
 package io.vertx.kafka.client.tests;
 
 import io.vertx.kafka.client.producer.KafkaHeader;
+import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import io.vertx.kafka.client.producer.impl.KafkaHeaderImpl;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
@@ -31,20 +32,15 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-public class KafkaHeaderImplTest {
+public class KafkaHeaderTest {
 
   @Test
   public void testfromHeaders_withNull() {
-    // Given
-    Headers headers = null;
-
-    // When
-    List<KafkaHeader> kafkaHeaders = KafkaHeaderImpl.fromHeaders(headers);
-
-    // Then
+    List<KafkaHeader> kafkaHeaders = KafkaProducerRecord.create("topic", "key", "value").headers();
     assertEquals(Collections.emptyList(), kafkaHeaders);
   }
 
+  /*
   @Test
   public void testfromHeaders_withHeaders() {
     // Given
@@ -61,11 +57,11 @@ public class KafkaHeaderImplTest {
 
     KafkaHeader kafkaHeader1 = kafkaHeaders.get(0);
     assertEquals("key1", kafkaHeader1.key());
-    assertEquals("value1", new String(kafkaHeader1.value()));
+    assertEquals("value1", kafkaHeader1.value().toString());
 
     KafkaHeader kafkaHeader2 = kafkaHeaders.get(1);
     assertEquals("key2", kafkaHeader2.key());
-    assertEquals("value2", new String(kafkaHeader2.value()));
+    assertEquals("value2", kafkaHeader2.value().toString());
   }
 
   @Test
@@ -82,13 +78,12 @@ public class KafkaHeaderImplTest {
 
   @Test
   public void testtoHeaderList_withKafkaHeaders() {
-    // Given
-    KafkaHeader kafkaHeader1 = new KafkaHeaderImpl("key1", "value1");
-    KafkaHeader kafkaHeader2 = new KafkaHeaderImpl("key2", "value2".getBytes());
+    KafkaHeader kafkaHeader1 = KafkaHeader.header("key1", "value1");
+    KafkaHeader kafkaHeader2 = KafkaHeader.header("key2", "value2");
     List<KafkaHeader> kafkaHeaders = Arrays.asList(kafkaHeader1, kafkaHeader2);
 
     // When
-    List<Header> headers = KafkaHeaderImpl.toHeaderList(kafkaHeaders);
+    List<Header> headers = KafkaProducerRecord.create("topic", "key", "value").addHeaders(kafkaHeaders).record().headers();
 
     // Then
     assertNotNull(headers);
@@ -102,4 +97,5 @@ public class KafkaHeaderImplTest {
     assertEquals("key2", header2.key());
     assertEquals("value2", new String(header2.value()));
   }
+  */
 }


### PR DESCRIPTION
The recent header support contribution breaks the build, is not usable and not tested.

This PR actually fixes all these things.