### PR TITLE
Upgrade Kafka client to 2.1.1 to fix DNS issue with Kubernetes broker restarts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
-    <kafka.version>2.1.0</kafka.version>
+    <kafka.version>2.1.1</kafka.version>
     <debezium.version>0.8.3.Final</debezium.version>
   </properties>
 


### PR DESCRIPTION
Follow-up on 3d2186b7578a06938cb8b637e57cc0a86b116dc7

See https://issues.apache.org/jira/browse/KAFKA-7755:
> Everyone running Kafka 2.1 or later on top of Kubernetes is impacted when a rolling restart is performed.

I've tested with 2.1.1 with quarkus.
