### PR TITLE
added kafka transaction support

### DIFF
--- a/src/main/java/io/vertx/kafka/client/producer/KafkaProducer.java
+++ b/src/main/java/io/vertx/kafka/client/producer/KafkaProducer.java
@@ -224,6 +224,18 @@ public interface KafkaProducer<K, V> extends WriteStream<KafkaProducerRecord<K, 
   }
 
   @Fluent
+  KafkaProducer<K, V> initTransactions(Handler<AsyncResult<Void>> handler);
+
+  @Fluent
+  KafkaProducer<K, V> beginTransaction(Handler<AsyncResult<Void>> handler);
+
+  @Fluent
+  KafkaProducer<K, V> commitTransaction(Handler<AsyncResult<Void>> handler);
+
+  @Fluent
+  KafkaProducer<K, V> abortTransaction(Handler<AsyncResult<Void>> handler);
+
+  @Fluent
   @Override
   KafkaProducer<K, V> exceptionHandler(Handler<Throwable> handler);
 

--- a/src/main/java/io/vertx/kafka/client/producer/KafkaWriteStream.java
+++ b/src/main/java/io/vertx/kafka/client/producer/KafkaWriteStream.java
@@ -146,6 +146,38 @@ public interface KafkaWriteStream<K, V> extends WriteStream<ProducerRecord<K, V>
   KafkaWriteStream<K, V> drainHandler(@Nullable Handler<Void> handler);
 
   /**
+   * Initializes the underlying kafka transactional producer. See {@link KafkaProducer#initTransactions()} ()}
+   *
+   * @param handler handler called on operation completed
+   * @return current KafkaWriteStream instance
+   */
+  KafkaWriteStream<K, V> initTransactions(Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Starts a new kafka transaction. See {@link KafkaProducer#beginTransaction()}
+   *
+   * @param handler handler called on operation completed
+   * @return current KafkaWriteStream instance
+   */
+  KafkaWriteStream<K, V> beginTransaction(Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Commits the ongoing transaction. See {@link KafkaProducer#commitTransaction()}
+   *
+   * @param handler handler called on operation completed
+   * @return current KafkaWriteStream instance
+   */
+  KafkaWriteStream<K, V> commitTransaction(Handler<AsyncResult<Void>> handler);
+
+  /**
+   * Aborts the ongoing transaction. See {@link org.apache.kafka.clients.producer.KafkaProducer#abortTransaction()}
+   *
+   * @param handler handler called on operation completed
+   * @return current KafkaWriteStream instance
+   */
+  KafkaWriteStream<K, V> abortTransaction(Handler<AsyncResult<Void>> handler);
+
+  /**
    * Asynchronously write a record to a topic
    *
    * @param record  record to write

--- a/src/main/java/io/vertx/kafka/client/producer/impl/KafkaProducerImpl.java
+++ b/src/main/java/io/vertx/kafka/client/producer/impl/KafkaProducerImpl.java
@@ -131,6 +131,30 @@ public class KafkaProducerImpl<K, V> implements KafkaProducer<K, V> {
   }
 
   @Override
+  public KafkaProducer<K, V> initTransactions(Handler<AsyncResult<Void>> handler) {
+    this.stream.initTransactions(handler);
+    return this;
+  }
+
+  @Override
+  public KafkaProducer<K, V> beginTransaction(Handler<AsyncResult<Void>> handler) {
+    this.stream.beginTransaction(handler);
+    return this;
+  }
+
+  @Override
+  public KafkaProducer<K, V> commitTransaction(Handler<AsyncResult<Void>> handler) {
+    this.stream.commitTransaction(handler);
+    return this;
+  }
+
+  @Override
+  public KafkaProducer<K, V> abortTransaction(Handler<AsyncResult<Void>> handler) {
+    this.stream.abortTransaction(handler);
+    return this;
+  }
+
+  @Override
   public KafkaProducer<K, V> exceptionHandler(Handler<Throwable> handler) {
     this.stream.exceptionHandler(handler);
     return this;

--- a/src/main/java/io/vertx/kafka/client/producer/impl/KafkaWriteStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/producer/impl/KafkaWriteStreamImpl.java
@@ -179,6 +179,42 @@ public class KafkaWriteStreamImpl<K, V> implements KafkaWriteStream<K, V> {
   }
 
   @Override
+  public KafkaWriteStream<K, V> initTransactions(Handler<AsyncResult<Void>> handler) {
+    this.context.executeBlocking(future -> {
+      this.producer.initTransactions();
+      future.complete();
+    }, handler);
+    return this;
+  }
+
+  @Override
+  public KafkaWriteStream<K, V> beginTransaction(Handler<AsyncResult<Void>> handler) {
+    this.context.executeBlocking(future -> {
+      this.producer.beginTransaction();
+      future.complete();
+    }, handler);
+    return this;
+  }
+
+  @Override
+  public KafkaWriteStream<K, V> commitTransaction(Handler<AsyncResult<Void>> handler) {
+    this.context.executeBlocking(future -> {
+      this.producer.commitTransaction();
+      future.complete();
+    }, handler);
+    return this;
+  }
+
+  @Override
+  public KafkaWriteStream<K, V> abortTransaction(Handler<AsyncResult<Void>> handler) {
+    this.context.executeBlocking(future -> {
+      this.producer.abortTransaction();
+      future.complete();
+    }, handler);
+    return this;
+  }
+
+  @Override
   public KafkaWriteStreamImpl<K, V> exceptionHandler(Handler<Throwable> handler) {
     this.exceptionHandler = handler;
     return this;

--- a/src/main/java/io/vertx/kafka/client/producer/impl/KafkaWriteStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/producer/impl/KafkaWriteStreamImpl.java
@@ -180,38 +180,22 @@ public class KafkaWriteStreamImpl<K, V> implements KafkaWriteStream<K, V> {
 
   @Override
   public KafkaWriteStream<K, V> initTransactions(Handler<AsyncResult<Void>> handler) {
-    this.context.executeBlocking(future -> {
-      this.producer.initTransactions();
-      future.complete();
-    }, handler);
-    return this;
+    return executeBlocking(handler, this.producer::initTransactions);
   }
 
   @Override
   public KafkaWriteStream<K, V> beginTransaction(Handler<AsyncResult<Void>> handler) {
-    this.context.executeBlocking(future -> {
-      this.producer.beginTransaction();
-      future.complete();
-    }, handler);
-    return this;
+    return executeBlocking(handler, this.producer::beginTransaction);
   }
 
   @Override
   public KafkaWriteStream<K, V> commitTransaction(Handler<AsyncResult<Void>> handler) {
-    this.context.executeBlocking(future -> {
-      this.producer.commitTransaction();
-      future.complete();
-    }, handler);
-    return this;
+    return executeBlocking(handler, this.producer::commitTransaction);
   }
 
   @Override
   public KafkaWriteStream<K, V> abortTransaction(Handler<AsyncResult<Void>> handler) {
-    this.context.executeBlocking(future -> {
-      this.producer.abortTransaction();
-      future.complete();
-    }, handler);
-    return this;
+    return executeBlocking(handler, this.producer::abortTransaction);
   }
 
   @Override
@@ -304,4 +288,23 @@ public class KafkaWriteStreamImpl<K, V> implements KafkaWriteStream<K, V> {
   public Producer<K, V> unwrap() {
     return this.producer;
   }
+
+  private KafkaWriteStreamImpl<K, V> executeBlocking(final Handler<AsyncResult<Void>> handler, final BlockingStatement statement) {
+    this.context.executeBlocking(promise -> {
+      try {
+        statement.execute();
+        promise.complete();
+      } catch (Exception e) {
+        promise.fail(e);
+      }
+    }, handler);
+    return this;
+  }
+
+  @FunctionalInterface
+  private interface BlockingStatement {
+
+    void execute();
+  }
+
 }

--- a/src/test/java/io/vertx/kafka/client/tests/TransactionalProducerTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/TransactionalProducerTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2016 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.kafka.client.tests;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.kafka.client.consumer.KafkaReadStream;
+import io.vertx.kafka.client.producer.KafkaWriteStream;
+
+/**
+ * Transactional Producer tests
+ */
+public class TransactionalProducerTest extends KafkaClusterTestBase {
+
+  private Vertx vertx;
+  private KafkaWriteStream<String, String> producer;
+
+  @BeforeClass
+  public static void setUp() throws IOException {
+    // Override to use 3 broker setup
+    kafkaCluster = kafkaCluster().deleteDataPriorToStartup(true).addBrokers(3).startup();
+  }
+
+  @Before
+  public void beforeTest() {
+    vertx = Vertx.vertx();
+  }
+
+  @After
+  public void afterTest(TestContext ctx) {
+    close(ctx, producer);
+    vertx.close(ctx.asyncAssertSuccess());
+  }
+
+  @Before
+  public void init(TestContext ctx) {
+    final Properties config = kafkaCluster.useTo().getProducerProperties("testTransactional_producer");
+    config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    config.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "producer-1");
+    config.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
+    config.put(ProducerConfig.ACKS_CONFIG, "all");
+
+    producer = producer(Vertx.vertx(), config);
+    producer.exceptionHandler(ctx::fail);
+  }
+
+  @Test
+  public void producedRecordsAreSeenAfterTheyHaveBeenCommitted(TestContext ctx) {
+    final String topicName = "transactionalProduce";
+    int numMessages = 1000;
+
+    final Async done = ctx.async();
+    final AtomicInteger seq = new AtomicInteger();
+    final KafkaReadStream<String, String> consumer = consumer(topicName);
+    consumer.exceptionHandler(ctx::fail);
+    consumer.handler(record -> {
+      int count = seq.getAndIncrement();
+      ctx.assertEquals("key-" + count, record.key());
+      ctx.assertEquals("value-" + count, record.value());
+      ctx.assertEquals("header_value-" + count, new String(record.headers().headers("header_key").iterator().next().value()));
+      if (count == numMessages) {
+        done.complete();
+      }
+    });
+    consumer.subscribe(Collections.singleton(topicName));
+
+    producer.initTransactions(ctx.asyncAssertSuccess());
+    producer.beginTransaction(ctx.asyncAssertSuccess());
+    for (int i = 0; i <= numMessages; i++) {
+      final ProducerRecord<String, String> record = createRecord(topicName, i);
+      producer.write(record, ctx.asyncAssertSuccess());
+    }
+    producer.commitTransaction(ctx.asyncAssertSuccess());
+  }
+
+  @Test
+  public void abortTransactionKeepsTopicEmpty(TestContext ctx) {
+    final String topicName = "transactionalProduceAbort";
+    final Async done = ctx.async();
+
+    producer.initTransactions(ctx.asyncAssertSuccess());
+    producer.beginTransaction(ctx.asyncAssertSuccess());
+    final ProducerRecord<String, String> record_0 = createRecord(topicName, 0);
+    producer.write(record_0, whenWritten -> {
+      producer.abortTransaction(ctx.asyncAssertSuccess());
+      final KafkaReadStream<String, String> consumer = consumer(topicName);
+      consumer.exceptionHandler(ctx::fail);
+      consumer.subscribe(Collections.singleton(topicName));
+      consumer.poll(5000, records -> {
+        ctx.assertTrue(records.result().isEmpty());
+        done.complete();
+      });
+    });
+  }
+
+  private <K, V> KafkaReadStream<K, V> consumer(final String topicName) {
+    final Properties config = kafkaCluster.useTo().getConsumerProperties("group-" + topicName, "consumer-" + topicName, OffsetResetStrategy.EARLIEST);
+    config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    config.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+    return KafkaReadStream.create(vertx, config);
+  }
+
+  private ProducerRecord<String, String> createRecord(final String topicName, final int i) {
+    final ProducerRecord<String, String> record = new ProducerRecord<>(topicName, 0, "key-" + i, "value-" + i);
+    record.headers().add("header_key", ("header_value-" + i).getBytes());
+    return record;
+  }
+
+}


### PR DESCRIPTION
## Motivation
Currently the Vert.x Kafka Producer does not expose methods to use a transactional kafka producer. To use the producer in a transactional way the methods should be exposed and run on a worker executor thread.

## Testing
Unit testing with the embedded kafka cluster from debezium is always very cumbersome. I am using the `kafka-junit4` dependency for some while which makes it way easier to test. Please tell me if that is ok. A big benefit is a use of the junit rules.

This my first pull request to this library, so please tell me if everything is ok there. 🙂 