### PR TITLE
Remove kafka as runtime dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,33 +68,11 @@
       <version>${kafka.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka_2.12</artifactId>
-      <version>${kafka.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.scala-lang</groupId>
-          <artifactId>scala-library</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
     <!-- Kafka requires these dependencies: declare this dependency to force vertx-kafka-client to use this one. These are the versions used by vert.x -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.21</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.21</version>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
     </dependency>
 
     <dependency>
@@ -122,9 +100,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.scala-lang</groupId>
-      <artifactId>scala-library</artifactId>
-      <version>2.12.4</version>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka_2.12</artifactId>
+      <version>${kafka.version}</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
As now all the logic of the vertx-kafka-client goes over the kafka-client library.

This makes this library a lot lighter.
The following deps were removed:
|    +--- org.apache.kafka:kafka_2.12:2.3.0
|    |    +--- org.apache.kafka:kafka-clients:2.3.0 (*)
|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.9.9 -> 2.9.9.1 (*)
|    |    +--- com.fasterxml.jackson.module:jackson-module-scala_2.12:2.9.9
|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.9.9
|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.9.9
|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.9.9 -> 2.9.9.1 (*)
|    |    |    \--- com.fasterxml.jackson.module:jackson-module-paranamer:2.9.9
|    |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.9.9 -> 2.9.9.1 (*)
|    |    |         \--- com.thoughtworks.paranamer:paranamer:2.8
|    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.9.9
|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.9.9 -> 2.9.9.1 (*)
|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.9.0 -> 2.9.9
|    |    |    \--- com.fasterxml.jackson.core:jackson-core:2.9.9
|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.9.9
|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.9.9
|    |    |    \--- com.fasterxml.jackson.core:jackson-databind:2.9.9 -> 2.9.9.1 (*)
|    |    +--- net.sf.jopt-simple:jopt-simple:5.0.4
|    |    +--- com.yammer.metrics:metrics-core:2.2.0
|    |    |    \--- org.slf4j:slf4j-api:1.7.2 -> 1.7.28
|    |    +--- org.scala-lang:scala-reflect:2.12.8
|    |    +--- com.typesafe.scala-logging:scala-logging_2.12:3.9.0
|    |    |    +--- org.scala-lang:scala-reflect:2.12.4 -> 2.12.8
|    |    |    \--- org.slf4j:slf4j-api:1.7.25 -> 1.7.28
|    |    +--- org.slf4j:slf4j-api:1.7.26 -> 1.7.28
|    |    +--- com.101tec:zkclient:0.11
|    |    |    \--- org.slf4j:slf4j-api:1.6.1 -> 1.7.28
|    |    \--- org.apache.zookeeper:zookeeper:3.4.14
|    |         +--- org.slf4j:slf4j-api:1.7.25 -> 1.7.28
|    |         +--- com.github.spotbugs:spotbugs-annotations:3.1.9
|    |         |    \--- com.google.code.findbugs:jsr305:3.0.2
|    |         \--- org.apache.yetus:audience-annotations:0.5.0
