### PR TITLE
Ensure that shutdown runs on a different thread

### DIFF
--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
@@ -678,12 +678,15 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
     if (this.closed.compareAndSet(false, true)) {
       this.worker.submit(() -> {
         this.consumer.close();
-        this.context.runOnContext(v -> {
+        // always execute the shutdown code in a new thread instead of on the context
+        // which may have been closed
+        Thread completionHandlerExecutorThread = new Thread(() -> {
           this.worker.shutdownNow();
           if (completionHandler != null) {
             completionHandler.handle(Future.succeededFuture());
           }
         });
+        completionHandlerExecutorThread.start();
       });
       this.consumer.wakeup();
     }


### PR DESCRIPTION
This is meant to avoid cases where the Context had already been shutdown.
See: https://github.com/quarkusio/quarkus/issues/4834.

Basically what was observed is that in a Quarkus application that contains Kafka Client and Mailer, the Kafka Client could not shutdown properly because  `io.vertx.core.impl.ContextImpl#runOnContext`
was throwing a `java.util.concurrent.RejectedExecutionException`  with a message saying that event executor has been terminated.