### PR TITLE
migrate consumer poll to use java.time.Duration as parameter

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -165,7 +165,7 @@ the list of the current assigned partitions.
 == Receiving messages with explicit polling
 
 Other than using the internal polling mechanism in order to receive messages from Kafka, the client can subscribe to a
-topic, avoiding to register the handler for getting the messages and then using the {@link io.vertx.kafka.client.consumer.KafkaConsumer#poll(long, io.vertx.core.Handler)} method.
+topic, avoiding to register the handler for getting the messages and then using the {@link io.vertx.kafka.client.consumer.KafkaConsumer#poll(Duration, io.vertx.core.Handler)} method.
 
 In this way, the user application is in charge to execute the poll for getting messages when it needs, for example after processing
 the previous ones.

--- a/src/main/java/examples/VertxKafkaClientExamples.java
+++ b/src/main/java/examples/VertxKafkaClientExamples.java
@@ -34,6 +34,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -324,7 +325,7 @@ public class VertxKafkaClientExamples {
 
         vertx.setPeriodic(1000, timerId -> {
 
-          consumer.poll(100, ar1 -> {
+          consumer.poll(Duration.ofMillis(100), ar1 -> {
 
             if (ar1.succeeded()) {
 

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
@@ -30,6 +30,7 @@ import io.vertx.kafka.client.consumer.impl.KafkaConsumerImpl;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.serialization.Deserializer;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -807,16 +808,26 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
 
   /**
    * Sets the poll timeout (in ms) for the underlying native Kafka Consumer. Defaults to 1000.
+   *
+   * @deprecated use {@link #pollTimeout(Duration)}
+   */
+  @Deprecated
+  @Fluent
+  KafkaConsumer<K, V> pollTimeout(long timeout);
+
+  /**
+   * Sets the poll timeout for the underlying native Kafka Consumer. Defaults to 1000ms.
    * Setting timeout to a lower value results in a more 'responsive' client, because it will block for a shorter period
    * if no data is available in the assigned partition and therefore allows subsequent actions to be executed with a shorter
    * delay. At the same time, the client will poll more frequently and thus will potentially create a higher load on the Kafka Broker.
    *
-   * @param timeout The time, in milliseconds, spent waiting in poll if data is not available in the buffer.
+   * @param timeout The time, spent waiting in poll if data is not available in the buffer.
    * If 0, returns immediately with any records that are available currently in the native Kafka consumer's buffer,
    * else returns empty. Must not be negative.
    */
   @Fluent
-  KafkaConsumer<K, V> pollTimeout(long timeout);
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  KafkaConsumer<K, V> pollTimeout(Duration timeout);
 
   /**
    * Executes a poll for getting messages from Kafka
@@ -825,12 +836,33 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
    *                If 0, returns immediately with any records that are available currently in the native Kafka consumer's buffer,
    *                else returns empty. Must not be negative.
    * @param handler handler called after the poll with batch of records (can be empty).
+   *
+   * @deprecated use {@link #poll(Duration, Handler)}
    */
+  @Deprecated
   void poll(long timeout, Handler<AsyncResult<KafkaConsumerRecords<K, V>>> handler);
 
   /**
-   * Like {@link #poll(long, Handler)} but returns a {@code Future} of the asynchronous result
+   * Executes a poll for getting messages from Kafka.
+   *
+   * @param timeout The maximum time to block (must not be greater than {@link Long#MAX_VALUE} milliseconds)
+   * @param handler handler called after the poll with batch of records (can be empty).
    */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  void poll(Duration timeout, Handler<AsyncResult<KafkaConsumerRecords<K, V>>> handler);
+
+  /**
+   * Like {@link #poll(long, Handler)} but returns a {@code Future} of the asynchronous result
+   *
+   * @deprecated use {@link #poll(Duration)}
+   */
+  @Deprecated
   Future<KafkaConsumerRecords<K, V>> poll(long timeout);
+
+  /**
+   * Like {@link #poll(Duration, Handler)} but returns a {@code Future} of the asynchronous result
+   */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  Future<KafkaConsumerRecords<K, V>> poll(Duration timeout);
 
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
@@ -807,15 +807,6 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
   Consumer<K, V> unwrap();
 
   /**
-   * Sets the poll timeout (in ms) for the underlying native Kafka Consumer. Defaults to 1000.
-   *
-   * @deprecated use {@link #pollTimeout(Duration)}
-   */
-  @Deprecated
-  @Fluent
-  KafkaConsumer<K, V> pollTimeout(long timeout);
-
-  /**
    * Sets the poll timeout for the underlying native Kafka Consumer. Defaults to 1000ms.
    * Setting timeout to a lower value results in a more 'responsive' client, because it will block for a shorter period
    * if no data is available in the assigned partition and therefore allows subsequent actions to be executed with a shorter
@@ -830,19 +821,6 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
   KafkaConsumer<K, V> pollTimeout(Duration timeout);
 
   /**
-   * Executes a poll for getting messages from Kafka
-   *
-   * @param timeout The time, in milliseconds, spent waiting in poll if data is not available in the buffer.
-   *                If 0, returns immediately with any records that are available currently in the native Kafka consumer's buffer,
-   *                else returns empty. Must not be negative.
-   * @param handler handler called after the poll with batch of records (can be empty).
-   *
-   * @deprecated use {@link #poll(Duration, Handler)}
-   */
-  @Deprecated
-  void poll(long timeout, Handler<AsyncResult<KafkaConsumerRecords<K, V>>> handler);
-
-  /**
    * Executes a poll for getting messages from Kafka.
    *
    * @param timeout The maximum time to block (must not be greater than {@link Long#MAX_VALUE} milliseconds)
@@ -850,14 +828,6 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   void poll(Duration timeout, Handler<AsyncResult<KafkaConsumerRecords<K, V>>> handler);
-
-  /**
-   * Like {@link #poll(long, Handler)} but returns a {@code Future} of the asynchronous result
-   *
-   * @deprecated use {@link #poll(Duration)}
-   */
-  @Deprecated
-  Future<KafkaConsumerRecords<K, V>> poll(long timeout);
 
   /**
    * Like {@link #poll(Duration, Handler)} but returns a {@code Future} of the asynchronous result

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
@@ -620,41 +620,12 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
   KafkaReadStream<K, V> pollTimeout(Duration timeout);
 
   /**
-   * Sets the poll timeout (in ms) for the underlying native Kafka Consumer. Defaults to 1000.
-   *
-   * @deprecated use {@link #pollTimeout(Duration)}
-   */
-  @Deprecated
-  KafkaReadStream<K, V> pollTimeout(long timeout);
-
-  /**
-   * Executes a poll for getting messages from Kafka
-   *
-   * @param timeout The time, in milliseconds, spent waiting in poll if data is not available in the buffer.
-   *                If 0, returns immediately with any records that are available currently in the native Kafka consumer's buffer,
-   *                else returns empty. Must not be negative.
-   * @param handler handler called after the poll with batch of records (can be empty).
-   *
-   * @deprecated use {@link #poll(Duration, Handler)}
-   */
-  @Deprecated
-  void poll(long timeout, Handler<AsyncResult<ConsumerRecords<K, V>>> handler);
-
-  /**
    * Executes a poll for getting messages from Kafka.
    *
    * @param timeout The maximum time to block (must not be greater than {@link Long#MAX_VALUE} milliseconds)
    * @param handler handler called after the poll with batch of records (can be empty).
    */
   void poll(Duration timeout, Handler<AsyncResult<ConsumerRecords<K, V>>> handler);
-
-  /**
-   * Like {@link #poll(long, Handler)} but returns a {@code Future} of the asynchronous result
-   *
-   * @deprecated use {@link #poll(Duration)}
-   */
-  @Deprecated
-  Future<ConsumerRecords<K, V>> poll(long timeout);
 
   /**
    * Like {@link #poll(Duration, Handler)} but returns a {@code Future} of the asynchronous result

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Deserializer;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -607,15 +608,23 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
   KafkaReadStream<K, V> batchHandler(Handler<ConsumerRecords<K, V>> handler);
 
   /**
-   * Sets the poll timeout (in ms) for the underlying native Kafka Consumer. Defaults to 1000.
+   * Sets the poll timeout for the underlying native Kafka Consumer. Defaults to 1000 ms.
    * Setting timeout to a lower value results in a more 'responsive' client, because it will block for a shorter period
    * if no data is available in the assigned partition and therefore allows subsequent actions to be executed with a shorter
    * delay. At the same time, the client will poll more frequently and thus will potentially create a higher load on the Kafka Broker.
    *
-   * @param timeout The time, in milliseconds, spent waiting in poll if data is not available in the buffer.
+   * @param timeout The time, spent waiting in poll if data is not available in the buffer.
    * If 0, returns immediately with any records that are available currently in the native Kafka consumer's buffer,
    * else returns empty. Must not be negative.
    */
+  KafkaReadStream<K, V> pollTimeout(Duration timeout);
+
+  /**
+   * Sets the poll timeout (in ms) for the underlying native Kafka Consumer. Defaults to 1000.
+   *
+   * @deprecated use {@link #pollTimeout(Duration)}
+   */
+  @Deprecated
   KafkaReadStream<K, V> pollTimeout(long timeout);
 
   /**
@@ -625,11 +634,30 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
    *                If 0, returns immediately with any records that are available currently in the native Kafka consumer's buffer,
    *                else returns empty. Must not be negative.
    * @param handler handler called after the poll with batch of records (can be empty).
+   *
+   * @deprecated use {@link #poll(Duration, Handler)}
    */
+  @Deprecated
   void poll(long timeout, Handler<AsyncResult<ConsumerRecords<K, V>>> handler);
 
   /**
-   * Like {@link #poll(long, Handler)} but returns a {@code Future} of the asynchronous result
+   * Executes a poll for getting messages from Kafka.
+   *
+   * @param timeout The maximum time to block (must not be greater than {@link Long#MAX_VALUE} milliseconds)
+   * @param handler handler called after the poll with batch of records (can be empty).
    */
+  void poll(Duration timeout, Handler<AsyncResult<ConsumerRecords<K, V>>> handler);
+
+  /**
+   * Like {@link #poll(long, Handler)} but returns a {@code Future} of the asynchronous result
+   *
+   * @deprecated use {@link #poll(Duration)}
+   */
+  @Deprecated
   Future<ConsumerRecords<K, V>> poll(long timeout);
+
+  /**
+   * Like {@link #poll(Duration, Handler)} but returns a {@code Future} of the asynchronous result
+   */
+  Future<ConsumerRecords<K, V>> poll(Duration timeout);
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
@@ -36,6 +36,7 @@ import io.vertx.kafka.client.consumer.KafkaReadStream;
 import io.vertx.kafka.client.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.Consumer;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -668,6 +669,12 @@ public class KafkaConsumerImpl<K, V> implements KafkaConsumer<K, V> {
   }
 
   @Override
+  public KafkaConsumer<K, V> pollTimeout(final Duration timeout) {
+    this.stream.pollTimeout(timeout);
+    return this;
+  }
+
+  @Override
   public KafkaConsumer<K, V> pollTimeout(long timeout) {
     this.stream.pollTimeout(timeout);
     return this;
@@ -675,6 +682,11 @@ public class KafkaConsumerImpl<K, V> implements KafkaConsumer<K, V> {
 
   @Override
   public void poll(long timeout, Handler<AsyncResult<KafkaConsumerRecords<K, V>>> handler) {
+    poll(Duration.ofMillis(timeout), handler);
+  }
+
+  @Override
+  public void poll(final Duration timeout, final Handler<AsyncResult<KafkaConsumerRecords<K, V>>> handler) {
     stream.poll(timeout, done -> {
       if (done.succeeded()) {
         handler.handle(Future.succeededFuture(new KafkaConsumerRecordsImpl<>(done.result())));
@@ -686,6 +698,11 @@ public class KafkaConsumerImpl<K, V> implements KafkaConsumer<K, V> {
 
   @Override
   public Future<KafkaConsumerRecords<K, V>> poll(long timeout) {
+    return poll(Duration.ofMillis(timeout));
+  }
+
+  @Override
+  public Future<KafkaConsumerRecords<K, V>> poll(final Duration timeout) {
     Promise<KafkaConsumerRecords<K, V>> promise = Promise.promise();
     poll(timeout, promise);
     return promise.future();

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
@@ -23,7 +23,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.streams.ReadStream;
 import io.vertx.kafka.client.consumer.OffsetAndTimestamp;
 import io.vertx.kafka.client.common.impl.CloseHandler;
 import io.vertx.kafka.client.common.impl.Helper;
@@ -675,17 +674,6 @@ public class KafkaConsumerImpl<K, V> implements KafkaConsumer<K, V> {
   }
 
   @Override
-  public KafkaConsumer<K, V> pollTimeout(long timeout) {
-    this.stream.pollTimeout(timeout);
-    return this;
-  }
-
-  @Override
-  public void poll(long timeout, Handler<AsyncResult<KafkaConsumerRecords<K, V>>> handler) {
-    poll(Duration.ofMillis(timeout), handler);
-  }
-
-  @Override
   public void poll(final Duration timeout, final Handler<AsyncResult<KafkaConsumerRecords<K, V>>> handler) {
     stream.poll(timeout, done -> {
       if (done.succeeded()) {
@@ -694,11 +682,6 @@ public class KafkaConsumerImpl<K, V> implements KafkaConsumer<K, V> {
         handler.handle(Future.failedFuture(done.cause()));
       }
     });
-  }
-
-  @Override
-  public Future<KafkaConsumerRecords<K, V>> poll(long timeout) {
-    return poll(Duration.ofMillis(timeout));
   }
 
   @Override

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
@@ -838,17 +838,6 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
   }
 
   @Override
-  public KafkaReadStream<K, V> pollTimeout(long timeout) {
-    this.pollTimeout = Duration.ofMillis(timeout);
-    return this;
-  }
-
-  @Override
-  public void poll(long timeout, Handler<AsyncResult<ConsumerRecords<K, V>>> handler) {
-    poll(Duration.ofMillis(timeout), handler);
-  }
-
-  @Override
   public void poll(final Duration timeout, final Handler<AsyncResult<ConsumerRecords<K, V>>> handler) {
     this.worker.submit(() -> {
       if (!this.closed.get()) {
@@ -862,13 +851,6 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
         }
       }
     });
-  }
-
-  @Override
-  public Future<ConsumerRecords<K, V>> poll(long timeout) {
-    final Promise<ConsumerRecords<K, V>> promise = Promise.promise();
-    poll(timeout, promise);
-    return promise.future();
   }
 
   @Override

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -68,7 +69,7 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
   private Handler<ConsumerRecords<K, V>> batchHandler;
   private Handler<Set<TopicPartition>> partitionsRevokedHandler;
   private Handler<Set<TopicPartition>> partitionsAssignedHandler;
-  private long pollTimeout = 1000L;
+  private Duration pollTimeout = Duration.ofSeconds(1);
 
   private ExecutorService worker;
 
@@ -831,13 +832,24 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
   }
 
   @Override
-  public KafkaReadStream<K, V> pollTimeout(long timeout) {
+  public KafkaReadStream<K, V> pollTimeout(final Duration timeout) {
     this.pollTimeout = timeout;
     return this;
   }
 
   @Override
+  public KafkaReadStream<K, V> pollTimeout(long timeout) {
+    this.pollTimeout = Duration.ofMillis(timeout);
+    return this;
+  }
+
+  @Override
   public void poll(long timeout, Handler<AsyncResult<ConsumerRecords<K, V>>> handler) {
+    poll(Duration.ofMillis(timeout), handler);
+  }
+
+  @Override
+  public void poll(final Duration timeout, final Handler<AsyncResult<ConsumerRecords<K, V>>> handler) {
     this.worker.submit(() -> {
       if (!this.closed.get()) {
         try {
@@ -854,7 +866,14 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
 
   @Override
   public Future<ConsumerRecords<K, V>> poll(long timeout) {
-    Promise<ConsumerRecords<K, V>> promise = Promise.promise();
+    final Promise<ConsumerRecords<K, V>> promise = Promise.promise();
+    poll(timeout, promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<ConsumerRecords<K, V>> poll(final Duration timeout) {
+    final Promise<ConsumerRecords<K, V>> promise = Promise.promise();
     poll(timeout, promise);
     return promise.future();
   }

--- a/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
@@ -1366,7 +1366,7 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
 
     int pollingTimeout = 1500;
     // Set the polling timeout to 1500 ms (default is 1000)
-    consumerWithCustomTimeout.pollTimeout(pollingTimeout);
+    consumerWithCustomTimeout.pollTimeout(Duration.ofMillis(pollingTimeout));
     // Subscribe to the empty topic (we want the poll() call to timeout!)
     consumerWithCustomTimeout.subscribe(topicName, subscribeRes -> {
       consumerWithCustomTimeout.handler(rec -> {}); // Consumer will now immediately poll once

--- a/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
@@ -41,6 +41,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -442,7 +443,7 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
     subscribe.await();
 
     Async consume = ctx.async();
-    consumer.poll(10000, rec -> {
+    consumer.poll(Duration.ofSeconds(10), rec -> {
       if (rec.result().count() == 10) {
         consume.countDown();
       }
@@ -1431,7 +1432,7 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
       if (subscribeResult.succeeded()) {
 
         vertx.setPeriodic(1000, t -> {
-          consumer.poll(100, pollResult -> {
+          consumer.poll(Duration.ofMillis(100), pollResult -> {
             if (pollResult.succeeded()) {
               if (count.updateAndGet(o -> count.get() - pollResult.result().size()) == 0) {
                 vertx.cancelTimer(t);
@@ -1465,7 +1466,7 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
       if (subscribeResult.succeeded()) {
 
         vertx.setPeriodic(1000, t -> {
-          consumer.poll(100, pollResult -> {
+          consumer.poll(Duration.ofMillis(100), pollResult -> {
             if (pollResult.succeeded()) {
               if (pollResult.result().size() > 0) {
                 ctx.fail();

--- a/src/test/java/io/vertx/kafka/client/tests/EarliestNativeTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/EarliestNativeTest.java
@@ -6,6 +6,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,7 +27,7 @@ public class EarliestNativeTest {
     consumer.subscribe(Collections.singleton("my-topic"));
 
     while (true) {
-      ConsumerRecords<String, String> records = consumer.poll(1000);
+      ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(1000));
       for (ConsumerRecord<String, String> record: records) {
         System.out.println(record);
       }

--- a/src/test/java/io/vertx/kafka/client/tests/TransactionalProducerTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/TransactionalProducerTest.java
@@ -17,6 +17,7 @@
 package io.vertx.kafka.client.tests;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -119,7 +120,7 @@ public class TransactionalProducerTest extends KafkaClusterTestBase {
       final KafkaReadStream<String, String> consumer = consumer(topicName);
       consumer.exceptionHandler(ctx::fail);
       consumer.subscribe(Collections.singleton(topicName));
-      consumer.poll(5000, records -> {
+      consumer.poll(Duration.ofSeconds(5), records -> {
         ctx.assertTrue(records.result().isEmpty());
         done.complete();
       });


### PR DESCRIPTION
Resolves #154 

1. I encountered an issue when adding a `poll(Duration timeout)` method to the `io.vertx.kafka.client.consumer.KafkaConsumer` class. The build fails with: 
```
SEVERE: io.vertx.codegen.CodeGenProcessor - Could not generate model for io.vertx.kafka.client.consumer.KafkaConsumer#poll(java.time.Duration): type java.time.Duration is not legal for use for a parameter in code generation
io.vertx.codegen.GenException: type java.time.Duration is not legal for use for a parameter in code generation

Could not generate model for io.vertx.kafka.client.consumer.KafkaConsumer#poll(java.time.Duration): type java.time.Duration is not legal for use for a parameter in code generation
Future<KafkaConsumerRecords<K, V>> poll(Duration timeout);
```
How can this be resolved? 

2. Another question I have is if you prefer to deprecate the methods with `poll(long timeout)`? As it is in the underlying KafkaConsumer.
