### PR TITLE
Adds consumergroup related APIs to the admin client

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -155,6 +155,16 @@ Set if consumer group is simple or not
 +++
 |===
 
+[[ListConsumerGroupOffsetsOptions]]
+== ListConsumerGroupOffsetsOptions
+
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|===
+
 [[MemberAssignment]]
 == MemberAssignment
 

--- a/src/main/generated/io/vertx/kafka/admin/ListConsumerGroupOffsetsOptionsConverter.java
+++ b/src/main/generated/io/vertx/kafka/admin/ListConsumerGroupOffsetsOptionsConverter.java
@@ -1,0 +1,28 @@
+package io.vertx.kafka.admin;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.kafka.admin.ListConsumerGroupOffsetsOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.kafka.admin.ListConsumerGroupOffsetsOptions} original class using Vert.x codegen.
+ */
+public class ListConsumerGroupOffsetsOptionsConverter {
+
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ListConsumerGroupOffsetsOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+      }
+    }
+  }
+
+  public static void toJson(ListConsumerGroupOffsetsOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(ListConsumerGroupOffsetsOptions obj, java.util.Map<String, Object> json) {
+  }
+}

--- a/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
+++ b/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
@@ -16,12 +16,6 @@
 
 package io.vertx.kafka.admin;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.Future;
 import io.vertx.kafka.client.common.ConfigResource;
@@ -32,6 +26,15 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.kafka.admin.impl.KafkaAdminClientImpl;
+import io.vertx.kafka.client.common.ConfigResource;
+import io.vertx.kafka.client.common.TopicPartition;
+import io.vertx.kafka.client.consumer.OffsetAndMetadata;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import org.apache.kafka.clients.admin.AdminClient;
 
 /**
  * Vert.x Kafka Admin client implementation
@@ -193,6 +196,68 @@ public interface KafkaAdminClient {
   Future<ClusterDescription> describeCluster();
 
   /**
+   * Delete consumer groups from the cluster.
+   *
+   * @param groupIds the ids of the groups to delete
+   */
+  void deleteConsumerGroups(List<java.lang.String> groupIds, Handler<AsyncResult<Void>> completionHandler);
+
+  /**
+   * Like {@link #deleteConsumerGroups(List, Handler)} but returns a {@code Future} of the asynchronous result
+   */
+  Future<Void> deleteConsumerGroups(List<java.lang.String> groupIds);
+
+  /**
+   * List the consumer group offsets available in the cluster.
+   *
+   * @param groupId The group id of the group whose offsets will be listed
+   * @param options The options to use when listing the consumer group offsets.
+   * @param completionHandler handler called on operation completed with the consumer groups offsets
+   */
+  @GenIgnore
+  void listConsumerGroupOffsets(String groupId, ListConsumerGroupOffsetsOptions options, Handler<AsyncResult<Map<TopicPartition, OffsetAndMetadata>>> completionHandler);
+
+  /**
+   * Like {@link #listConsumerGroupOffsets(String, ListConsumerGroupOffsetsOptions, Handler)} but returns a {@code Future} of the asynchronous result
+   */
+  @GenIgnore
+  Future<Map<TopicPartition, OffsetAndMetadata>> listConsumerGroupOffsets(String groupId, ListConsumerGroupOffsetsOptions options);
+
+  /**
+   * List the consumer group offsets available in the cluster.
+   *
+   * @param groupId The group id of the group whose offsets will be listed
+   * @param completionHandler handler called on operation completed with the consumer groups offsets
+   */
+  @GenIgnore
+  default void listConsumerGroupOffsets(String groupId, Handler<AsyncResult<Map<TopicPartition, OffsetAndMetadata>>> completionHandler) {
+    listConsumerGroupOffsets(groupId, new ListConsumerGroupOffsetsOptions(), completionHandler);
+  }
+
+  /**
+   * Like {@link #listConsumerGroupOffsets(String, Handler)} but returns a {@code Future} of the asynchronous result
+   */
+  @GenIgnore
+  default Future<Map<TopicPartition, OffsetAndMetadata>> listConsumerGroupOffsets(String groupId) {
+    return listConsumerGroupOffsets(groupId, new ListConsumerGroupOffsetsOptions());
+  }
+
+  /**
+   * Delete committed offsets for a set of partitions in a consumer group. This will
+   * succeed at the partition level only if the group is not actively subscribed
+   * to the corresponding topic.
+   *
+   * @param groupId The group id of the group whose offsets will be listed
+   * @param partitions The set of partitions in the consumer group whose offsets will be deleted
+   */
+  void deleteConsumerGroupOffsets(String groupId, Set<TopicPartition> partitions, Handler<AsyncResult<Void>> completionHandler);
+
+  /**
+   * Like {@link #deleteConsumerGroupOffsets(String, Set, Handler)} but returns a {@code Future} of the asynchronous result
+   */
+  Future<Void> deleteConsumerGroupOffsets(String groupId, Set<TopicPartition> partitions);
+
+  /**
    * Close the admin client
    *
    * @return a {@code Future} completed with the operation result
@@ -201,7 +266,7 @@ public interface KafkaAdminClient {
 
   /**
    * Close the admin client
-   * 
+   *
    * @param timeout timeout to wait for closing
    * @return a {@code Future} completed with the operation result
    */

--- a/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
+++ b/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
@@ -176,12 +176,12 @@ public interface KafkaAdminClient {
    * @param groupIds the ids of the groups to describe
    * @param completionHandler handler called on operation completed with the consumer groups descriptions
    */
-  void describeConsumerGroups(List<java.lang.String> groupIds, Handler<AsyncResult<Map<String, ConsumerGroupDescription>>> completionHandler);
+  void describeConsumerGroups(List<String> groupIds, Handler<AsyncResult<Map<String, ConsumerGroupDescription>>> completionHandler);
 
   /**
    * Like {@link #describeConsumerGroups(List, Handler)} but returns a {@code Future} of the asynchronous result
    */
-  Future<Map<String, ConsumerGroupDescription>> describeConsumerGroups(List<java.lang.String> groupIds);
+  Future<Map<String, ConsumerGroupDescription>> describeConsumerGroups(List<String> groupIds);
 
   /**
    * Describe the nodes in the cluster with the default options
@@ -199,13 +199,14 @@ public interface KafkaAdminClient {
    * Delete consumer groups from the cluster.
    *
    * @param groupIds the ids of the groups to delete
+   * @param completionHandler handler called on operation completed
    */
-  void deleteConsumerGroups(List<java.lang.String> groupIds, Handler<AsyncResult<Void>> completionHandler);
+  void deleteConsumerGroups(List<String> groupIds, Handler<AsyncResult<Void>> completionHandler);
 
   /**
    * Like {@link #deleteConsumerGroups(List, Handler)} but returns a {@code Future} of the asynchronous result
    */
-  Future<Void> deleteConsumerGroups(List<java.lang.String> groupIds);
+  Future<Void> deleteConsumerGroups(List<String> groupIds);
 
   /**
    * List the consumer group offsets available in the cluster.

--- a/src/main/java/io/vertx/kafka/admin/ListConsumerGroupOffsetsOptions.java
+++ b/src/main/java/io/vertx/kafka/admin/ListConsumerGroupOffsetsOptions.java
@@ -13,9 +13,7 @@ public class ListConsumerGroupOffsetsOptions {
   /**
    * Constructor
    */
-  public ListConsumerGroupOffsetsOptions() {
-
-  }
+  public ListConsumerGroupOffsetsOptions() {}
 
   /**
    * Constructor (from JSON representation)
@@ -23,7 +21,6 @@ public class ListConsumerGroupOffsetsOptions {
    * @param json  JSON representation
    */
   public ListConsumerGroupOffsetsOptions(JsonObject json) {
-
     ListConsumerGroupOffsetsOptionsConverter.fromJson(json, this);
   }
 
@@ -52,7 +49,6 @@ public class ListConsumerGroupOffsetsOptions {
    * @return  JSON representation
    */
   public JsonObject toJson() {
-
     JsonObject json = new JsonObject();
     ListConsumerGroupOffsetsOptionsConverter.toJson(this, json);
     return json;

--- a/src/main/java/io/vertx/kafka/admin/ListConsumerGroupOffsetsOptions.java
+++ b/src/main/java/io/vertx/kafka/admin/ListConsumerGroupOffsetsOptions.java
@@ -1,0 +1,68 @@
+package io.vertx.kafka.admin;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.common.TopicPartition;
+import java.util.List;
+
+@DataObject(generateConverter = true)
+public class ListConsumerGroupOffsetsOptions {
+
+  private List<TopicPartition> topicPartitions = null;
+
+  /**
+   * Constructor
+   */
+  public ListConsumerGroupOffsetsOptions() {
+
+  }
+
+  /**
+   * Constructor (from JSON representation)
+   *
+   * @param json  JSON representation
+   */
+  public ListConsumerGroupOffsetsOptions(JsonObject json) {
+
+    ListConsumerGroupOffsetsOptionsConverter.fromJson(json, this);
+  }
+
+  /**
+   * Set the topic partitions to list as part of the result.
+   * {@code null} includes all topic partitions.
+   *
+   * @param topicPartitions List of topic partitions to include
+   * @return This ListGroupOffsetsOptions
+   */
+  public ListConsumerGroupOffsetsOptions topicPartitions(List<TopicPartition> topicPartitions) {
+    this.topicPartitions = topicPartitions;
+    return this;
+  }
+
+  /**
+   * Returns a list of topic partitions to add as part of the result.
+   */
+  public List<TopicPartition> topicPartitions() {
+    return topicPartitions;
+  }
+
+  /**
+   * Convert object to JSON representation
+   *
+   * @return  JSON representation
+   */
+  public JsonObject toJson() {
+
+    JsonObject json = new JsonObject();
+    ListConsumerGroupOffsetsOptionsConverter.toJson(this, json);
+    return json;
+  }
+
+  @Override
+  public String toString() {
+    return "ListConsumerGroupOffsetsOptions{" +
+      "topicPartitions=" + topicPartitions +
+      '}';
+  }
+
+}

--- a/src/main/java/io/vertx/kafka/admin/impl/KafkaAdminClientImpl.java
+++ b/src/main/java/io/vertx/kafka/admin/impl/KafkaAdminClientImpl.java
@@ -304,7 +304,6 @@ public class KafkaAdminClientImpl implements KafkaAdminClient {
 
           consumerGroups.put(cgDescriptionEntry.getKey(), consumerGroupDescription);
         }
-
         promise.complete(consumerGroups);
       } else {
         promise.fail(ex);
@@ -325,13 +324,11 @@ public class KafkaAdminClientImpl implements KafkaAdminClient {
     listConsumerGroupOffsetsResult.partitionsToOffsetAndMetadata().whenComplete((cgo, ex) -> {
 
       if (ex == null) {
-
         Map<TopicPartition, OffsetAndMetadata> consumerGroupOffsets = new HashMap<>();
 
         for (Map.Entry<org.apache.kafka.common.TopicPartition, org.apache.kafka.clients.consumer.OffsetAndMetadata> cgoOffset : cgo.entrySet()) {
           consumerGroupOffsets.put(Helper.from(cgoOffset.getKey()), Helper.from(cgoOffset.getValue()));
         }
-
         promise.complete(consumerGroupOffsets);
       } else {
         promise.fail(ex);
@@ -352,7 +349,6 @@ public class KafkaAdminClientImpl implements KafkaAdminClient {
 
     DeleteConsumerGroupsResult deleteConsumerGroupsResult = this.adminClient.deleteConsumerGroups(groupIds);
     deleteConsumerGroupsResult.all().whenComplete((v, ex) -> {
-
       if (ex == null) {
         promise.complete();
       } else {
@@ -374,7 +370,6 @@ public class KafkaAdminClientImpl implements KafkaAdminClient {
 
     DeleteConsumerGroupOffsetsResult deleteConsumerGroupOffsetsResult = this.adminClient.deleteConsumerGroupOffsets(groupId, Helper.toTopicPartitionSet(partitions));
     deleteConsumerGroupOffsetsResult.all().whenComplete((v, ex) -> {
-
       if (ex == null) {
         promise.complete();
       } else {

--- a/src/main/java/io/vertx/kafka/admin/impl/KafkaAdminClientImpl.java
+++ b/src/main/java/io/vertx/kafka/admin/impl/KafkaAdminClientImpl.java
@@ -16,6 +16,9 @@
 
 package io.vertx.kafka.admin.impl;
 
+import io.vertx.kafka.admin.ListConsumerGroupOffsetsOptions;
+import io.vertx.kafka.client.common.TopicPartition;
+import io.vertx.kafka.client.consumer.OffsetAndMetadata;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -42,11 +45,14 @@ import io.vertx.kafka.client.common.impl.Helper;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.DeleteConsumerGroupOffsetsResult;
+import org.apache.kafka.clients.admin.DeleteConsumerGroupsResult;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.admin.DescribeConsumerGroupsResult;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult;
 import org.apache.kafka.clients.admin.ListConsumerGroupsResult;
 import org.apache.kafka.clients.admin.ListTopicsResult;
 
@@ -300,6 +306,77 @@ public class KafkaAdminClientImpl implements KafkaAdminClient {
         }
 
         promise.complete(consumerGroups);
+      } else {
+        promise.fail(ex);
+      }
+    });
+    return promise.future();
+  }
+
+  public void listConsumerGroupOffsets(String groupId, ListConsumerGroupOffsetsOptions options, Handler<AsyncResult<Map<TopicPartition, OffsetAndMetadata>>> completionHandler) {
+    listConsumerGroupOffsets(groupId, options).onComplete(completionHandler);
+  }
+
+  public Future<Map<TopicPartition, OffsetAndMetadata>> listConsumerGroupOffsets(String groupId, ListConsumerGroupOffsetsOptions options) {
+    ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    Promise<Map<TopicPartition, OffsetAndMetadata>> promise = ctx.promise();
+
+    ListConsumerGroupOffsetsResult listConsumerGroupOffsetsResult = this.adminClient.listConsumerGroupOffsets(groupId, Helper.to(options));
+    listConsumerGroupOffsetsResult.partitionsToOffsetAndMetadata().whenComplete((cgo, ex) -> {
+
+      if (ex == null) {
+
+        Map<TopicPartition, OffsetAndMetadata> consumerGroupOffsets = new HashMap<>();
+
+        for (Map.Entry<org.apache.kafka.common.TopicPartition, org.apache.kafka.clients.consumer.OffsetAndMetadata> cgoOffset : cgo.entrySet()) {
+          consumerGroupOffsets.put(Helper.from(cgoOffset.getKey()), Helper.from(cgoOffset.getValue()));
+        }
+
+        promise.complete(consumerGroupOffsets);
+      } else {
+        promise.fail(ex);
+      }
+    });
+    return promise.future();
+  }
+
+  @Override
+  public void deleteConsumerGroups(List<String> groupIds, Handler<AsyncResult<Void>> completionHandler) {
+    deleteConsumerGroups(groupIds).onComplete(completionHandler);
+  }
+
+  @Override
+  public Future<Void> deleteConsumerGroups(List<String> groupIds) {
+    ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    Promise<Void> promise = ctx.promise();
+
+    DeleteConsumerGroupsResult deleteConsumerGroupsResult = this.adminClient.deleteConsumerGroups(groupIds);
+    deleteConsumerGroupsResult.all().whenComplete((v, ex) -> {
+
+      if (ex == null) {
+        promise.complete();
+      } else {
+        promise.fail(ex);
+      }
+    });
+    return promise.future();
+  }
+
+  @Override
+  public void deleteConsumerGroupOffsets(String groupId, Set<TopicPartition> partitions, Handler<AsyncResult<Void>> completionHandler) {
+    deleteConsumerGroupOffsets(groupId, partitions).onComplete(completionHandler);
+  }
+
+  @Override
+  public Future<Void> deleteConsumerGroupOffsets(String groupId, Set<TopicPartition> partitions) {
+    ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    Promise<Void> promise = ctx.promise();
+
+    DeleteConsumerGroupOffsetsResult deleteConsumerGroupOffsetsResult = this.adminClient.deleteConsumerGroupOffsets(groupId, Helper.toTopicPartitionSet(partitions));
+    deleteConsumerGroupOffsetsResult.all().whenComplete((v, ex) -> {
+
+      if (ex == null) {
+        promise.complete();
       } else {
         promise.fail(ex);
       }

--- a/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
+++ b/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
@@ -20,6 +20,7 @@ import io.vertx.core.Handler;
 import io.vertx.kafka.admin.Config;
 import io.vertx.kafka.admin.ConfigEntry;
 import io.vertx.kafka.admin.ConsumerGroupListing;
+import io.vertx.kafka.admin.ListConsumerGroupOffsetsOptions;
 import io.vertx.kafka.admin.MemberAssignment;
 import io.vertx.kafka.admin.NewTopic;
 import io.vertx.kafka.client.common.ConfigResource;
@@ -29,6 +30,7 @@ import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.OffsetAndMetadata;
 import io.vertx.kafka.client.producer.RecordMetadata;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -201,5 +203,24 @@ public class Helper {
 
   public static MemberAssignment from(org.apache.kafka.clients.admin.MemberAssignment memberAssignment) {
     return new MemberAssignment(Helper.from(memberAssignment.topicPartitions()));
+  }
+
+  public static org.apache.kafka.clients.admin.ListConsumerGroupOffsetsOptions to(ListConsumerGroupOffsetsOptions listConsumerGroupOffsetsOptions) {
+
+    org.apache.kafka.clients.admin.ListConsumerGroupOffsetsOptions newListConsumerGroupOffsetsOptions = new org.apache.kafka.clients.admin.ListConsumerGroupOffsetsOptions();
+
+    if (listConsumerGroupOffsetsOptions.topicPartitions() != null) {
+      List<org.apache.kafka.common.TopicPartition> topicPartitions = listConsumerGroupOffsetsOptions.topicPartitions().stream()
+        .map(tp -> new org.apache.kafka.common.TopicPartition(tp.getTopic(), tp.getPartition()))
+        .collect(Collectors.toList());
+
+      newListConsumerGroupOffsetsOptions.topicPartitions(topicPartitions);
+    }
+
+    return newListConsumerGroupOffsetsOptions;
+  }
+
+  public static Set<org.apache.kafka.common.TopicPartition> toTopicPartitionSet(Set<TopicPartition> partitions) {
+    return partitions.stream().map(Helper::to).collect(Collectors.toSet());
   }
 }


### PR DESCRIPTION
Adds the `deleteConsumerGroups`, `listConsumerGroupOffsets` and `deleteConsumerGroupOffsets` apis.

Contributes to: vert-x3/vertx-kafka-client#158

Signed-off-by: Graeme McRobert <mcrobert@uk.ibm.com>