### PR TITLE
Add describeCluster to AdminClient

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -1,5 +1,22 @@
 = Cheatsheets
 
+[[ClusterDescription]]
+== ClusterDescription
+
+++++
+ A detailed description of the cluster
+++++
+'''
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[clusterId]]`@clusterId`|`String`|+++
+Set the cluster ID
++++
+|===
+
 [[Config]]
 == Config
 

--- a/src/main/generated/io/vertx/kafka/admin/ClusterDescriptionConverter.java
+++ b/src/main/generated/io/vertx/kafka/admin/ClusterDescriptionConverter.java
@@ -1,0 +1,44 @@
+package io.vertx.kafka.admin;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.kafka.admin.ClusterDescription}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.kafka.admin.ClusterDescription} original class using Vert.x codegen.
+ */
+public class ClusterDescriptionConverter {
+
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ClusterDescription obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "clusterId":
+          if (member.getValue() instanceof String) {
+            obj.setClusterId((String)member.getValue());
+          }
+          break;
+        case "controller":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setController(new io.vertx.kafka.client.common.Node((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(ClusterDescription obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(ClusterDescription obj, java.util.Map<String, Object> json) {
+    if (obj.getClusterId() != null) {
+      json.put("clusterId", obj.getClusterId());
+    }
+    if (obj.getController() != null) {
+      json.put("controller", obj.getController().toJson());
+    }
+  }
+}

--- a/src/main/java/io/vertx/kafka/admin/ClusterDescription.java
+++ b/src/main/java/io/vertx/kafka/admin/ClusterDescription.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2019 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.kafka.admin;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.common.Node;
+
+import java.util.Collection;
+
+/**
+ * A detailed description of the cluster
+ */
+@DataObject(generateConverter = true)
+public class ClusterDescription {
+  private String clusterId;
+  private Node controller;
+  private Collection<Node> nodes;
+
+  /**
+   * Constructor
+   */
+  public ClusterDescription() {
+
+  }
+
+  /**
+   * Constructor
+   *
+   * @param clusterId The cluster ID.
+   * @param controller The controller node.
+   * @param nodes A collection of nodes belonging to this cluster.
+   */
+  public ClusterDescription(String clusterId, Node controller, Collection<Node> nodes) {
+    this.clusterId = clusterId;
+    this.controller = controller;
+    this.nodes = nodes;
+  }
+
+  /**
+   * Constructor (from JSON representation)
+   *
+   * @param json  JSON representation
+   */
+  public ClusterDescription(JsonObject json) {
+
+    ClusterDescriptionConverter.fromJson(json, this);
+  }
+
+  /**
+   *
+   * @return the nodes belonging to this cluster.
+   */
+  public Collection<Node> getNodes() {
+    return nodes;
+  }
+
+  /**
+   * Set the nodes belonging to this cluster
+   *
+   * @param nodes the nodes
+   * @return current instance of the class to be fluent
+   */
+  public ClusterDescription setNodes(Collection<Node> nodes) {
+    this.nodes = nodes;
+    return this;
+  }
+
+  /**
+   *
+   * @return the controller node.
+   */
+  public Node getController() {
+    return controller;
+  }
+
+  /**
+   * Set the controller node.
+   *
+   * @param controller the controller node
+   * @return current instance of the class to be fluent
+   */
+  public ClusterDescription setController(Node controller) {
+    this.controller = controller;
+    return this;
+  }
+
+  /**
+   *
+   * @return the cluster ID
+   */
+  public String getClusterId() {
+    return clusterId;
+  }
+
+  /**
+   * Set the cluster ID
+   *
+   * @param clusterId
+   * @return current instance of the class to be fluent
+   */
+  public ClusterDescription setClusterId(String clusterId) {
+    this.clusterId = clusterId;
+    return this;
+  }
+
+  /**
+   * Convert object to JSON representation
+   *
+   * @return  JSON representation
+   */
+  public JsonObject toJson() {
+
+    JsonObject json = new JsonObject();
+    ClusterDescriptionConverter.toJson(this, json);
+    return json;
+  }
+
+  @Override
+  public String toString() {
+
+    return "ClusterDescription{" +
+      "clusterId=" + this.clusterId +
+      ",controller=" + this.controller +
+      ",nodes=" + this.nodes +
+      "}";
+  }
+}

--- a/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
+++ b/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
@@ -181,6 +181,18 @@ public interface KafkaAdminClient {
   Future<Map<String, ConsumerGroupDescription>> describeConsumerGroups(List<java.lang.String> groupIds);
 
   /**
+   * Describe the nodes in the cluster with the default options
+   *
+   * @param completionHandler handler called on operation completed with the cluster description
+   */
+  void describeCluster(Handler<AsyncResult<ClusterDescription>> completionHandler);
+
+  /**
+   * Like {@link #describeCluster(Handler)} but returns a {@code Future} of the asynchronous result
+   */
+  Future<ClusterDescription> describeCluster();
+
+  /**
    * Close the admin client
    *
    * @return a {@code Future} completed with the operation result


### PR DESCRIPTION
Signed-off-by: Aki Yoshida <elakito@gmail.com>

Motivation:

describeCluster of Kafka's AdminClient which returns the cluster information is not supported by Vertx's Kafka AdminClient. This PR adds this method.

Please look at this PR.
Regards, aki

