### PR TITLE
Revert "migrate consumer poll to use java.time.Duration as parameter"

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -165,7 +165,7 @@ the list of the current assigned partitions.
 == Receiving messages with explicit polling
 
 Other than using the internal polling mechanism in order to receive messages from Kafka, the client can subscribe to a
-topic, avoiding to register the handler for getting the messages and then using the {@link io.vertx.kafka.client.consumer.KafkaConsumer#poll(Duration, io.vertx.core.Handler)} method.
+topic, avoiding to register the handler for getting the messages and then using the {@link io.vertx.kafka.client.consumer.KafkaConsumer#poll(long, io.vertx.core.Handler)} method.
 
 In this way, the user application is in charge to execute the poll for getting messages when it needs, for example after processing
 the previous ones.

--- a/src/main/java/examples/VertxKafkaClientExamples.java
+++ b/src/main/java/examples/VertxKafkaClientExamples.java
@@ -34,7 +34,6 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
-import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -325,7 +324,7 @@ public class VertxKafkaClientExamples {
 
         vertx.setPeriodic(1000, timerId -> {
 
-          consumer.poll(Duration.ofMillis(100), ar1 -> {
+          consumer.poll(100, ar1 -> {
 
             if (ar1.succeeded()) {
 

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
@@ -30,7 +30,6 @@ import io.vertx.kafka.client.consumer.impl.KafkaConsumerImpl;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.serialization.Deserializer;
 
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -807,32 +806,31 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
   Consumer<K, V> unwrap();
 
   /**
-   * Sets the poll timeout for the underlying native Kafka Consumer. Defaults to 1000ms.
+   * Sets the poll timeout (in ms) for the underlying native Kafka Consumer. Defaults to 1000.
    * Setting timeout to a lower value results in a more 'responsive' client, because it will block for a shorter period
    * if no data is available in the assigned partition and therefore allows subsequent actions to be executed with a shorter
    * delay. At the same time, the client will poll more frequently and thus will potentially create a higher load on the Kafka Broker.
    *
-   * @param timeout The time, spent waiting in poll if data is not available in the buffer.
+   * @param timeout The time, in milliseconds, spent waiting in poll if data is not available in the buffer.
    * If 0, returns immediately with any records that are available currently in the native Kafka consumer's buffer,
    * else returns empty. Must not be negative.
    */
   @Fluent
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  KafkaConsumer<K, V> pollTimeout(Duration timeout);
+  KafkaConsumer<K, V> pollTimeout(long timeout);
 
   /**
-   * Executes a poll for getting messages from Kafka.
+   * Executes a poll for getting messages from Kafka
    *
-   * @param timeout The maximum time to block (must not be greater than {@link Long#MAX_VALUE} milliseconds)
+   * @param timeout The time, in milliseconds, spent waiting in poll if data is not available in the buffer.
+   *                If 0, returns immediately with any records that are available currently in the native Kafka consumer's buffer,
+   *                else returns empty. Must not be negative.
    * @param handler handler called after the poll with batch of records (can be empty).
    */
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  void poll(Duration timeout, Handler<AsyncResult<KafkaConsumerRecords<K, V>>> handler);
+  void poll(long timeout, Handler<AsyncResult<KafkaConsumerRecords<K, V>>> handler);
 
   /**
-   * Like {@link #poll(Duration, Handler)} but returns a {@code Future} of the asynchronous result
+   * Like {@link #poll(long, Handler)} but returns a {@code Future} of the asynchronous result
    */
-  @GenIgnore(GenIgnore.PERMITTED_TYPE)
-  Future<KafkaConsumerRecords<K, V>> poll(Duration timeout);
+  Future<KafkaConsumerRecords<K, V>> poll(long timeout);
 
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
@@ -33,7 +33,6 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Deserializer;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -608,27 +607,29 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
   KafkaReadStream<K, V> batchHandler(Handler<ConsumerRecords<K, V>> handler);
 
   /**
-   * Sets the poll timeout for the underlying native Kafka Consumer. Defaults to 1000 ms.
+   * Sets the poll timeout (in ms) for the underlying native Kafka Consumer. Defaults to 1000.
    * Setting timeout to a lower value results in a more 'responsive' client, because it will block for a shorter period
    * if no data is available in the assigned partition and therefore allows subsequent actions to be executed with a shorter
    * delay. At the same time, the client will poll more frequently and thus will potentially create a higher load on the Kafka Broker.
    *
-   * @param timeout The time, spent waiting in poll if data is not available in the buffer.
+   * @param timeout The time, in milliseconds, spent waiting in poll if data is not available in the buffer.
    * If 0, returns immediately with any records that are available currently in the native Kafka consumer's buffer,
    * else returns empty. Must not be negative.
    */
-  KafkaReadStream<K, V> pollTimeout(Duration timeout);
+  KafkaReadStream<K, V> pollTimeout(long timeout);
 
   /**
-   * Executes a poll for getting messages from Kafka.
+   * Executes a poll for getting messages from Kafka
    *
-   * @param timeout The maximum time to block (must not be greater than {@link Long#MAX_VALUE} milliseconds)
+   * @param timeout The time, in milliseconds, spent waiting in poll if data is not available in the buffer.
+   *                If 0, returns immediately with any records that are available currently in the native Kafka consumer's buffer,
+   *                else returns empty. Must not be negative.
    * @param handler handler called after the poll with batch of records (can be empty).
    */
-  void poll(Duration timeout, Handler<AsyncResult<ConsumerRecords<K, V>>> handler);
+  void poll(long timeout, Handler<AsyncResult<ConsumerRecords<K, V>>> handler);
 
   /**
-   * Like {@link #poll(Duration, Handler)} but returns a {@code Future} of the asynchronous result
+   * Like {@link #poll(long, Handler)} but returns a {@code Future} of the asynchronous result
    */
-  Future<ConsumerRecords<K, V>> poll(Duration timeout);
+  Future<ConsumerRecords<K, V>> poll(long timeout);
 }

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
@@ -23,6 +23,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.streams.ReadStream;
 import io.vertx.kafka.client.consumer.OffsetAndTimestamp;
 import io.vertx.kafka.client.common.impl.CloseHandler;
 import io.vertx.kafka.client.common.impl.Helper;
@@ -35,7 +36,6 @@ import io.vertx.kafka.client.consumer.KafkaReadStream;
 import io.vertx.kafka.client.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.Consumer;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -668,13 +668,13 @@ public class KafkaConsumerImpl<K, V> implements KafkaConsumer<K, V> {
   }
 
   @Override
-  public KafkaConsumer<K, V> pollTimeout(final Duration timeout) {
+  public KafkaConsumer<K, V> pollTimeout(long timeout) {
     this.stream.pollTimeout(timeout);
     return this;
   }
 
   @Override
-  public void poll(final Duration timeout, final Handler<AsyncResult<KafkaConsumerRecords<K, V>>> handler) {
+  public void poll(long timeout, Handler<AsyncResult<KafkaConsumerRecords<K, V>>> handler) {
     stream.poll(timeout, done -> {
       if (done.succeeded()) {
         handler.handle(Future.succeededFuture(new KafkaConsumerRecordsImpl<>(done.result())));
@@ -685,7 +685,7 @@ public class KafkaConsumerImpl<K, V> implements KafkaConsumer<K, V> {
   }
 
   @Override
-  public Future<KafkaConsumerRecords<K, V>> poll(final Duration timeout) {
+  public Future<KafkaConsumerRecords<K, V>> poll(long timeout) {
     Promise<KafkaConsumerRecords<K, V>> promise = Promise.promise();
     poll(timeout, promise);
     return promise.future();

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
@@ -33,7 +33,6 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
 
-import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -69,7 +68,7 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
   private Handler<ConsumerRecords<K, V>> batchHandler;
   private Handler<Set<TopicPartition>> partitionsRevokedHandler;
   private Handler<Set<TopicPartition>> partitionsAssignedHandler;
-  private Duration pollTimeout = Duration.ofSeconds(1);
+  private long pollTimeout = 1000L;
 
   private ExecutorService worker;
 
@@ -832,13 +831,13 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
   }
 
   @Override
-  public KafkaReadStream<K, V> pollTimeout(final Duration timeout) {
+  public KafkaReadStream<K, V> pollTimeout(long timeout) {
     this.pollTimeout = timeout;
     return this;
   }
 
   @Override
-  public void poll(final Duration timeout, final Handler<AsyncResult<ConsumerRecords<K, V>>> handler) {
+  public void poll(long timeout, Handler<AsyncResult<ConsumerRecords<K, V>>> handler) {
     this.worker.submit(() -> {
       if (!this.closed.get()) {
         try {
@@ -854,8 +853,8 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
   }
 
   @Override
-  public Future<ConsumerRecords<K, V>> poll(final Duration timeout) {
-    final Promise<ConsumerRecords<K, V>> promise = Promise.promise();
+  public Future<ConsumerRecords<K, V>> poll(long timeout) {
+    Promise<ConsumerRecords<K, V>> promise = Promise.promise();
     poll(timeout, promise);
     return promise.future();
   }

--- a/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
@@ -41,7 +41,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -443,7 +442,7 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
     subscribe.await();
 
     Async consume = ctx.async();
-    consumer.poll(Duration.ofSeconds(10), rec -> {
+    consumer.poll(10000, rec -> {
       if (rec.result().count() == 10) {
         consume.countDown();
       }
@@ -1366,7 +1365,7 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
 
     int pollingTimeout = 1500;
     // Set the polling timeout to 1500 ms (default is 1000)
-    consumerWithCustomTimeout.pollTimeout(Duration.ofMillis(pollingTimeout));
+    consumerWithCustomTimeout.pollTimeout(pollingTimeout);
     // Subscribe to the empty topic (we want the poll() call to timeout!)
     consumerWithCustomTimeout.subscribe(topicName, subscribeRes -> {
       consumerWithCustomTimeout.handler(rec -> {}); // Consumer will now immediately poll once
@@ -1432,7 +1431,7 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
       if (subscribeResult.succeeded()) {
 
         vertx.setPeriodic(1000, t -> {
-          consumer.poll(Duration.ofMillis(100), pollResult -> {
+          consumer.poll(100, pollResult -> {
             if (pollResult.succeeded()) {
               if (count.updateAndGet(o -> count.get() - pollResult.result().size()) == 0) {
                 vertx.cancelTimer(t);
@@ -1466,7 +1465,7 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
       if (subscribeResult.succeeded()) {
 
         vertx.setPeriodic(1000, t -> {
-          consumer.poll(Duration.ofMillis(100), pollResult -> {
+          consumer.poll(100, pollResult -> {
             if (pollResult.succeeded()) {
               if (pollResult.result().size() > 0) {
                 ctx.fail();

--- a/src/test/java/io/vertx/kafka/client/tests/EarliestNativeTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/EarliestNativeTest.java
@@ -6,7 +6,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
-import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,7 +26,7 @@ public class EarliestNativeTest {
     consumer.subscribe(Collections.singleton("my-topic"));
 
     while (true) {
-      ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(1000));
+      ConsumerRecords<String, String> records = consumer.poll(1000);
       for (ConsumerRecord<String, String> record: records) {
         System.out.println(record);
       }

--- a/src/test/java/io/vertx/kafka/client/tests/TransactionalProducerTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/TransactionalProducerTest.java
@@ -17,7 +17,6 @@
 package io.vertx.kafka.client.tests;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -120,7 +119,7 @@ public class TransactionalProducerTest extends KafkaClusterTestBase {
       final KafkaReadStream<String, String> consumer = consumer(topicName);
       consumer.exceptionHandler(ctx::fail);
       consumer.subscribe(Collections.singleton(topicName));
-      consumer.poll(Duration.ofSeconds(5), records -> {
+      consumer.poll(5000, records -> {
         ctx.assertTrue(records.result().isEmpty());
         done.complete();
       });


### PR DESCRIPTION
Reverts vert-x3/vertx-kafka-client#155