### PR TITLE
Add method to get current fetch amount to KafkaConsumer

### DIFF
--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
@@ -177,6 +177,18 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
   KafkaConsumer<K, V> endHandler(Handler<Void> endHandler);
 
   /**
+   * Returns the current fetch amount.
+   *
+   * <ul>
+   *   <i>If the stream is in <i>flowing</i> mode will return {@link Long#MAX_VALUE}.</i>
+   *   <li>If the stream is in <i>fetch</i> mode, will return the current number of elements still to be delivered or 0 if paused.</li>
+   * </ul>
+   *
+   * @return current fetch amount
+   */
+  long currentFetchAmount();
+
+  /**
    * Subscribe to the given topic to get dynamically assigned partitions.
    *
    * @param topic  topic to subscribe to

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
@@ -177,16 +177,16 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
   KafkaConsumer<K, V> endHandler(Handler<Void> endHandler);
 
   /**
-   * Returns the current fetch amount.
+   * Returns the current demand.
    *
    * <ul>
    *   <i>If the stream is in <i>flowing</i> mode will return {@link Long#MAX_VALUE}.</i>
    *   <li>If the stream is in <i>fetch</i> mode, will return the current number of elements still to be delivered or 0 if paused.</li>
    * </ul>
    *
-   * @return current fetch amount
+   * @return current demand
    */
-  long currentFetchAmount();
+  long demand();
 
   /**
    * Subscribe to the given topic to get dynamically assigned partitions.

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
@@ -70,6 +70,18 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
   KafkaReadStream<K, V> endHandler(@Nullable Handler<Void> endHandler);
 
   /**
+   * Returns the current fetch amount.
+   *
+   * <ul>
+   *   <i>If the stream is in <i>flowing</i> mode will return {@link Long#MAX_VALUE}.</i>
+   *   <li>If the stream is in <i>fetch</i> mode, will return the current number of elements still to be delivered or 0 if paused.</li>
+   * </ul>
+   *
+   * @return current fetch amount
+   */
+  long currentFetchAmount();
+
+  /**
    * Create a new KafkaReadStream instance
    *
    * @param vertx Vert.x instance to use

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
@@ -70,16 +70,16 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
   KafkaReadStream<K, V> endHandler(@Nullable Handler<Void> endHandler);
 
   /**
-   * Returns the current fetch amount.
+   * Returns the current demand.
    *
    * <ul>
    *   <i>If the stream is in <i>flowing</i> mode will return {@link Long#MAX_VALUE}.</i>
    *   <li>If the stream is in <i>fetch</i> mode, will return the current number of elements still to be delivered or 0 if paused.</li>
    * </ul>
    *
-   * @return current fetch amount
+   * @return current demand
    */
-  long currentFetchAmount();
+  long demand();
 
   /**
    * Create a new KafkaReadStream instance

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
@@ -104,6 +104,11 @@ public class KafkaConsumerImpl<K, V> implements KafkaConsumer<K, V> {
   }
 
   @Override
+  public long currentFetchAmount() {
+    return this.stream.currentFetchAmount();
+  }
+
+  @Override
   public Future<Void> pause(Set<TopicPartition> topicPartitions) {
     Promise<Void> promise = Promise.promise();
     this.pause(topicPartitions, promise);

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaConsumerImpl.java
@@ -104,8 +104,8 @@ public class KafkaConsumerImpl<K, V> implements KafkaConsumer<K, V> {
   }
 
   @Override
-  public long currentFetchAmount() {
-    return this.stream.currentFetchAmount();
+  public long demand() {
+    return this.stream.demand();
   }
 
   @Override

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
@@ -657,7 +657,7 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
   }
 
   @Override
-  public long currentFetchAmount() {
+  public long demand() {
     return this.demand.get();
   }
 

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
@@ -656,6 +656,11 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
     return this;
   }
 
+  @Override
+  public long currentFetchAmount() {
+    return this.demand.get();
+  }
+
   private KafkaReadStreamImpl<K, V> startConsuming() {
     this.consuming.set(true);
     this.schedule(0);

--- a/src/test/java/io/vertx/kafka/client/tests/KafkaReadStreamMockTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/KafkaReadStreamMockTest.java
@@ -86,11 +86,11 @@ public class KafkaReadStreamMockTest extends KafkaTestBase {
                 if(timer!=null) vertx.cancelTimer(timer);
                 timer = vertx.setTimer(5, (t)->{
                     consumerVertx.pause();
-                    ctx.assertEquals(0L, consumerVertx.currentFetchAmount());
+                    ctx.assertEquals(0L, consumerVertx.demand());
                     vertx.getOrCreateContext().runOnContext((t1)->{
                         consumerVertx.commit();
                         consumerVertx.resume();
-                        ctx.assertEquals(Long.MAX_VALUE, consumerVertx.currentFetchAmount());
+                        ctx.assertEquals(Long.MAX_VALUE, consumerVertx.demand());
                         sendNextBatch(consumer);
                         // sends two batches of messages
                         vertx.getOrCreateContext().runOnContext((t2)->{

--- a/src/test/java/io/vertx/kafka/client/tests/KafkaReadStreamMockTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/KafkaReadStreamMockTest.java
@@ -86,9 +86,11 @@ public class KafkaReadStreamMockTest extends KafkaTestBase {
                 if(timer!=null) vertx.cancelTimer(timer);
                 timer = vertx.setTimer(5, (t)->{
                     consumerVertx.pause();
+                    ctx.assertEquals(0L, consumerVertx.currentFetchAmount());
                     vertx.getOrCreateContext().runOnContext((t1)->{
                         consumerVertx.commit();
                         consumerVertx.resume();
+                        ctx.assertEquals(Long.MAX_VALUE, consumerVertx.currentFetchAmount());
                         sendNextBatch(consumer);
                         // sends two batches of messages
                         vertx.getOrCreateContext().runOnContext((t2)->{


### PR DESCRIPTION
Signed-off-by: Paulo Casaes <pcasaes@gmail.com>

Motivation:

On the smallrye-reactive-messaging project we are using the pause/resume (no parameters) methods when configure a consumer re-balance listener. The basic design is: pause when there's a re-balance and only resume after the listener has completed its work. We do this so as not to receive messages while waiting on an eventual asynchronous seek the listener may perform - a very common use case for the kafka consumer re-balance listener is to seek to specific offsets (see Kafka: The Definitive Guide page 85).

The particular problem we are having is described in this PR
https://github.com/smallrye/smallrye-reactive-messaging/pull/672

Basically it's not suppose to go to flowing mode which is what **resume** does, it's suppose to remain in **fetch** mode. To facilitate solving this particular problem it would be nice to have a way to know the current fetch amount.
