### PR TITLE
Bump Kafka version to 2.6.0 on 3.9.x version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <stack.version>3.9.3-SNAPSHOT</stack.version>
-    <kafka.version>2.4.0</kafka.version>
+    <kafka.version>2.6.0</kafka.version>
     <debezium.version>0.8.3.Final</debezium.version>
   </properties>
 


### PR DESCRIPTION
This PR fixes #182 for 3.9.x version.