### PR TITLE
Support tracing on send/receive messages

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -167,6 +167,12 @@ Set if consumer group is simple or not
 [frame="topbot"]
 |===
 ^|Name | Type ^| Description
+|[[tracePeerAddress]]`@tracePeerAddress`|`String`|+++
+Set the Kafka address for traces.
++++
+|[[tracingPolicy]]`@tracingPolicy`|`link:enums.html#TracingPolicy[TracingPolicy]`|+++
+Set the Kafka tracing policy.
++++
 |===
 
 [[ListConsumerGroupOffsetsOptions]]

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -168,7 +168,8 @@ Set if consumer group is simple or not
 |===
 ^|Name | Type ^| Description
 |[[tracePeerAddress]]`@tracePeerAddress`|`String`|+++
-Set the Kafka address for traces.
+Set the Kafka address to show in trace tags.
+ Or leave it unset to automatically pick up bootstrap server from config instead.
 +++
 |[[tracingPolicy]]`@tracingPolicy`|`link:enums.html#TracingPolicy[TracingPolicy]`|+++
 Set the Kafka tracing policy.

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -469,4 +469,16 @@ stream of {@link org.apache.kafka.clients.producer.ProducerRecord}.
 The API exposed by these interfaces is mostly the same than the polyglot version.
 endif::[]
 
+== Automatic trace propagation
+
+When Vert.x is configured with Tracing enabled (see {@link io.vertx.core.VertxOptions#setTracingOptions}),
+traces will be automatically propagated with Kafka messages.
+
+Kafka producers will add a span to traces when a message is being written, trace contexts
+will be propagated as Kafka headers, and the consumers will also create a span while reading a message.
+
+The span tags follow the
+link:https://github.com/opentracing/specification/blob/master/semantic_conventions.md[OpenTracing semantic convention].
+
+
 include::admin.adoc[]

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -477,8 +477,15 @@ traces will be automatically propagated with Kafka messages.
 Kafka producers will add a span to traces when a message is being written, trace contexts
 will be propagated as Kafka headers, and the consumers will also create a span while reading a message.
 
-The span tags follow the
-link:https://github.com/opentracing/specification/blob/master/semantic_conventions.md[OpenTracing semantic convention].
+Following the
+link:https://github.com/opentracing/specification/blob/master/semantic_conventions.md[OpenTracing semantic convention],
+span tags are:
 
+- `span.kind`, it is either `consumer` or `producer`
+- `peer.address` can be configured from {@link io.vertx.kafka.client.common.KafkaClientOptions#setTracePeerAddress}. If unset, it will be the configured bootstrap server.
+- `peer.hostname` is parsed from `peer.address`
+- `peer.port` is parsed from `peer.address`
+- `peer.service` is always `kafka`
+- `message_bus.destination`, which is set to the topic in use
 
 include::admin.adoc[]

--- a/src/main/generated/io/vertx/kafka/client/common/KafkaClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/kafka/client/common/KafkaClientOptionsConverter.java
@@ -26,6 +26,16 @@ public class KafkaClientOptionsConverter {
             obj.setConfig(map);
           }
           break;
+        case "tracePeerAddress":
+          if (member.getValue() instanceof String) {
+            obj.setTracePeerAddress((String)member.getValue());
+          }
+          break;
+        case "tracingPolicy":
+          if (member.getValue() instanceof String) {
+            obj.setTracingPolicy(io.vertx.core.tracing.TracingPolicy.valueOf((String)member.getValue()));
+          }
+          break;
       }
     }
   }
@@ -39,6 +49,12 @@ public class KafkaClientOptionsConverter {
       JsonObject map = new JsonObject();
       obj.getConfig().forEach((key, value) -> map.put(key, value));
       json.put("config", map);
+    }
+    if (obj.getTracePeerAddress() != null) {
+      json.put("tracePeerAddress", obj.getTracePeerAddress());
+    }
+    if (obj.getTracingPolicy() != null) {
+      json.put("tracingPolicy", obj.getTracingPolicy().name());
     }
   }
 }

--- a/src/main/java/io/vertx/kafka/client/common/KafkaClientOptions.java
+++ b/src/main/java/io/vertx/kafka/client/common/KafkaClientOptions.java
@@ -32,12 +32,12 @@ import java.util.Properties;
 @DataObject(generateConverter = true)
 public class KafkaClientOptions {
   /**
-   * Default registry name is 'default'
+   * Default peer address to set in traces tags is null, and will automatically pick up bootstrap server from config
    */
-  public static final String DEFAULT_TRACE_PEER_ADDRESS = "";
+  public static final String DEFAULT_TRACE_PEER_ADDRESS = null;
 
   /**
-   * Default registry name is 'default'
+   * Default tracing policy is 'propagate'
    */
   public static final TracingPolicy DEFAULT_TRACING_POLICY = TracingPolicy.PROPAGATE;
 
@@ -126,20 +126,17 @@ public class KafkaClientOptions {
   }
 
   /**
-   * @return the Kafka "peer address" to show in traces
+   * @return the Kafka "peer address" to show in trace tags
    */
   public String getTracePeerAddress() {
-    // Search for peer address in config if not provided
-    if (config != null && tracePeerAddress == null) {
-      return (String) config.getOrDefault(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "");
-    }
     return tracePeerAddress;
   }
 
   /**
-   * Set the Kafka address for traces.
+   * Set the Kafka address to show in trace tags.
+   * Or leave it unset to automatically pick up bootstrap server from config instead.
    *
-   * @param tracePeerAddress the Kafka "peer address" to show in traces
+   * @param tracePeerAddress the Kafka "peer address" to show in trace tags
    * @return a reference to this, so the API can be used fluently
    */
   public KafkaClientOptions setTracePeerAddress(String tracePeerAddress) {

--- a/src/main/java/io/vertx/kafka/client/common/tracing/ConsumerTracer.java
+++ b/src/main/java/io/vertx/kafka/client/common/tracing/ConsumerTracer.java
@@ -15,12 +15,12 @@
  */
 package io.vertx.kafka.client.common.tracing;
 
-import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.Context;
 import io.vertx.core.spi.tracing.TagExtractor;
 import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.kafka.client.common.KafkaClientOptions;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.utils.Utils;
@@ -40,19 +40,34 @@ public class ConsumerTracer<S> {
   private final String port;
   private final TracingPolicy policy;
 
-  public static <S> @Nullable ConsumerTracer create(VertxTracer tracer, KafkaClientOptions opts) {
+  /**
+   * Creates a ConsumerTracer, which provides an opinionated facade for using {@link io.vertx.core.spi.tracing.VertxTracer}
+   * with a Kafka Consumer use case.
+   * The method will return {@code null} if Tracing is not setup in Vert.x, or if {@code TracingPolicy.IGNORE} is used.
+   * @param tracer the generic tracer object
+   * @param opts Kafka client options
+   * @param <S> the type of spans that is going to be generated, depending on the tracing system (zipkin, opentracing ...)
+   * @return a new instance of {@code ConsumerTracer}, or {@code null}
+   */
+  public static <S> ConsumerTracer create(VertxTracer tracer, KafkaClientOptions opts) {
     TracingPolicy policy = opts.getTracingPolicy() != null ? opts.getTracingPolicy() : TracingPolicy.ALWAYS;
     if (policy == TracingPolicy.IGNORE || tracer == null) {
       // No need to create a tracer if it won't be used
       return null;
     }
-    return new ConsumerTracer<S>(tracer, policy, opts.getTracePeerAddress());
+    String address = opts.getTracePeerAddress();
+    // Search for peer address in config if not provided
+    if (address == null) {
+      if (opts.getConfig() != null) {
+        address = (String) opts.getConfig().getOrDefault(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "");
+      } else {
+        address = "";
+      }
+    }
+    return new ConsumerTracer<S>(tracer, policy, address);
   }
 
   private ConsumerTracer(VertxTracer<S, Void> tracer, TracingPolicy policy, String bootstrapServer) {
-    if (tracer == null) {
-      throw new IllegalArgumentException("tracer should not be null");
-    }
     this.tracer = tracer;
     this.address = bootstrapServer;
     this.hostname = Utils.getHost(bootstrapServer);

--- a/src/main/java/io/vertx/kafka/client/common/tracing/ConsumerTracer.java
+++ b/src/main/java/io/vertx/kafka/client/common/tracing/ConsumerTracer.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.kafka.client.common.tracing;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.spi.tracing.TagExtractor;
+import io.vertx.core.spi.tracing.VertxTracer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.utils.Utils;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.stream.StreamSupport;
+
+/**
+ * Tracer for Kafka consumer, wrapping the generic tracer.
+ */
+public class ConsumerTracer<S> {
+  private final VertxTracer<S, Void> tracer;
+  private final String address;
+  private final String hostname;
+  private final String port;
+
+  public static <S> @Nullable ConsumerTracer create(Vertx vertx, BiFunction<String, String, String> mapOrDefault) {
+    ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    if (ctx.tracer() == null) {
+      return null;
+    }
+    return new ConsumerTracer<S>(ctx.tracer(), mapOrDefault.apply(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, ""));
+  }
+
+  private ConsumerTracer(VertxTracer<S, Void> tracer, String bootstrapServer) {
+    if (tracer == null) {
+      throw new IllegalArgumentException("tracer should not be null");
+    }
+    this.tracer = tracer;
+    this.address = bootstrapServer;
+    this.hostname = Utils.getHost(bootstrapServer);
+    Integer port = Utils.getPort(bootstrapServer);
+    this.port = port == null ? null : port.toString();
+  }
+
+  private static Iterable<Map.Entry<String, String>> convertHeaders(Headers headers) {
+    if (headers == null) {
+      return Collections.emptyList();
+    }
+    return () -> StreamSupport.stream(headers.spliterator(), false)
+      .map(h -> (Map.Entry<String, String>) new AbstractMap.SimpleEntry<>(h.key(), new String(h.value()))).iterator();
+  }
+
+  public StartedSpan prepareMessageReceived(Context context, ConsumerRecord rec) {
+    TraceContext tc = new TraceContext("consumer", address, hostname, port, rec.topic());
+    S span = tracer.receiveRequest(context, tc, "kafka_receive", convertHeaders(rec.headers()), TraceTags.TAG_EXTRACTOR);
+    return new StartedSpan(span);
+  }
+
+  public class StartedSpan {
+    private final S span;
+
+    private StartedSpan(S span) {
+      this.span = span;
+    }
+
+    public void finish(Context context) {
+      // We don't add any new tag to the span here, just stop span timer
+      tracer.sendResponse(context, null, span, null, TagExtractor.empty());
+    }
+
+    public void fail(Context context, Throwable failure) {
+      tracer.sendResponse(context, null, span, failure, TagExtractor.empty());
+    }
+  }
+}

--- a/src/main/java/io/vertx/kafka/client/common/tracing/ProducerTracer.java
+++ b/src/main/java/io/vertx/kafka/client/common/tracing/ProducerTracer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.kafka.client.common.tracing;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.spi.tracing.TagExtractor;
+import io.vertx.core.spi.tracing.VertxTracer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.utils.Utils;
+
+import java.util.function.BiFunction;
+
+/**
+ * Tracer for Kafka producer, wrapping the generic tracer.
+ */
+public class ProducerTracer<S> {
+  private final VertxTracer<Void, S> tracer;
+  private final String address;
+  private final String hostname;
+  private final String port;
+
+  public static <S> @Nullable ProducerTracer create(Vertx vertx, BiFunction<String, String, String> mapOrDefault) {
+    ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    if (ctx.tracer() == null) {
+      return null;
+    }
+    return new ProducerTracer<S>(ctx.tracer(), mapOrDefault.apply(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, ""));
+  }
+
+  private ProducerTracer(VertxTracer<Void, S> tracer, String bootstrapServer) {
+    if (tracer == null) {
+      throw new IllegalArgumentException("tracer should not be null");
+    }
+    this.tracer = tracer;
+    this.address = bootstrapServer;
+    this.hostname = Utils.getHost(bootstrapServer);
+    Integer port = Utils.getPort(bootstrapServer);
+    this.port = port == null ? null : port.toString();
+  }
+
+  public StartedSpan prepareSendMessage(Context context, ProducerRecord record) {
+    TraceContext tc = new TraceContext("producer", address, hostname, port, record.topic());
+    S span = tracer.sendRequest(context, tc, "kafka_send", (k, v) -> record.headers().add(k, v.getBytes()), TraceTags.TAG_EXTRACTOR);
+    return new StartedSpan(span);
+  }
+
+  public class StartedSpan {
+    private final S span;
+
+    private StartedSpan(S span) {
+      this.span = span;
+    }
+
+    public void finish(Context context) {
+      // We don't add any new tag to the span here, just stop span timer
+      tracer.receiveResponse(context, null, span, null, TagExtractor.<TraceContext>empty());
+    }
+
+    public void fail(Context context, Throwable failure) {
+      tracer.receiveResponse(context, null, span, failure, TagExtractor.empty());
+    }
+  }
+}

--- a/src/main/java/io/vertx/kafka/client/common/tracing/TraceContext.java
+++ b/src/main/java/io/vertx/kafka/client/common/tracing/TraceContext.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.kafka.client.common.tracing;
+
+/**
+ * TraceContext holds some context for tracing during a message writing / reading process
+ */
+class TraceContext {
+  final String kind;
+  final String address;
+  final String hostname;
+  final String port;
+  final String topic;
+
+  TraceContext(String kind, String address, String hostname, String port, String topic) {
+    this.kind = kind;
+    this.address = address;
+    this.hostname = hostname;
+    this.port = port;
+    this.topic = topic;
+  }
+}

--- a/src/main/java/io/vertx/kafka/client/common/tracing/TraceTags.java
+++ b/src/main/java/io/vertx/kafka/client/common/tracing/TraceTags.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.kafka.client.common.tracing;
+
+import io.vertx.core.spi.tracing.TagExtractor;
+
+import java.util.function.Function;
+
+/**
+ * Tags for Kafka Tracing
+ */
+public enum TraceTags {
+  // See https://github.com/opentracing/specification/blob/master/semantic_conventions.md
+  SPAN_KIND("span.kind", q -> q.kind),
+  PEER_ADDRESS("peer.address", q -> q.address),
+  PEER_HOSTNAME("peer.hostname", q -> q.hostname),
+  PEER_PORT("peer.port", q -> q.port),
+  PEER_SERVICE("peer.service", q -> "kafka"),
+  BUS_DESTINATION("message_bus.destination", q -> q.topic);
+
+  static final TagExtractor<TraceContext> TAG_EXTRACTOR = new TagExtractor<TraceContext>() {
+    private final TraceTags[] TAGS = TraceTags.values();
+
+    @Override
+    public int len(TraceContext obj) {
+      return TAGS.length;
+    }
+    @Override
+    public String name(TraceContext obj, int index) {
+      return TAGS[index].name;
+    }
+    @Override
+    public String value(TraceContext obj, int index) {
+      return TAGS[index].fn.apply(obj);
+    }
+  };
+
+  final String name;
+  final Function<TraceContext, String> fn;
+
+  TraceTags(String name, Function<TraceContext, String> fn) {
+    this.name = name;
+    this.fn = fn;
+  }
+}

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
@@ -63,7 +63,7 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
   @GenIgnore
   static <K, V> KafkaConsumer<K, V> create(Vertx vertx, Consumer<K, V> consumer) {
     KafkaReadStream<K, V> stream = KafkaReadStream.create(vertx, consumer);
-    return new KafkaConsumerImpl<K, V>(stream);
+    return new KafkaConsumerImpl<>(stream);
   }
 
   /**

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
@@ -23,7 +23,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.kafka.client.common.KafkaClientOptions;
-import io.vertx.kafka.client.common.tracing.ConsumerTracer;
 import io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl;
 import io.vertx.kafka.client.serialization.VertxSerdes;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -92,8 +91,10 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
    * @return  an instance of the KafkaReadStream
    */
   static <K, V> KafkaReadStream<K, V> create(Vertx vertx, Properties config) {
-    ConsumerTracer tracer = ConsumerTracer.create(vertx, config::getProperty);
-    return new KafkaReadStreamImpl<>(vertx.getOrCreateContext(), new org.apache.kafka.clients.consumer.KafkaConsumer<>(config), tracer);
+    return new KafkaReadStreamImpl<>(
+      vertx,
+      new org.apache.kafka.clients.consumer.KafkaConsumer<>(config),
+      KafkaClientOptions.fromProperties(config, false));
   }
 
   /**
@@ -121,8 +122,10 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
    * @return  an instance of the KafkaReadStream
    */
   static <K, V> KafkaReadStream<K, V> create(Vertx vertx, Properties config, Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer) {
-    ConsumerTracer tracer = ConsumerTracer.create(vertx, config::getProperty);
-    return new KafkaReadStreamImpl<>(vertx.getOrCreateContext(), new org.apache.kafka.clients.consumer.KafkaConsumer<>(config, keyDeserializer, valueDeserializer), tracer);
+    return new KafkaReadStreamImpl<>(
+      vertx,
+      new org.apache.kafka.clients.consumer.KafkaConsumer<>(config, keyDeserializer, valueDeserializer),
+      KafkaClientOptions.fromProperties(config, false));
   }
 
   /**
@@ -133,8 +136,10 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
    * @return  an instance of the KafkaReadStream
    */
   static <K, V> KafkaReadStream<K, V> create(Vertx vertx, Map<String, Object> config) {
-    ConsumerTracer tracer = ConsumerTracer.create(vertx, (k, d) -> (String)(config.getOrDefault(k, d)));
-    return new KafkaReadStreamImpl<>(vertx.getOrCreateContext(), new org.apache.kafka.clients.consumer.KafkaConsumer<>(config), tracer);
+    return new KafkaReadStreamImpl<>(
+      vertx,
+      new org.apache.kafka.clients.consumer.KafkaConsumer<>(config),
+      KafkaClientOptions.fromMap(config, false));
   }
 
   /**
@@ -162,7 +167,10 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
    * @return  an instance of the KafkaReadStream
    */
   static <K, V> KafkaReadStream<K, V> create(Vertx vertx, Map<String, Object> config, Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer) {
-    return create(vertx, new org.apache.kafka.clients.consumer.KafkaConsumer<>(config, keyDeserializer, valueDeserializer));
+    return new KafkaReadStreamImpl<>(
+      vertx,
+      new org.apache.kafka.clients.consumer.KafkaConsumer<>(config, keyDeserializer, valueDeserializer),
+      KafkaClientOptions.fromMap(config, false));
   }
 
   /**
@@ -177,7 +185,7 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
     if (options.getConfig() != null) {
       config.putAll(options.getConfig());
     }
-    return create(vertx, new org.apache.kafka.clients.consumer.KafkaConsumer<>(config));
+    return new KafkaReadStreamImpl<>(vertx, new org.apache.kafka.clients.consumer.KafkaConsumer<>(config), options);
   }
 
   /**
@@ -209,7 +217,10 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
     if (options.getConfig() != null) {
       config.putAll(options.getConfig());
     }
-    return create(vertx, new org.apache.kafka.clients.consumer.KafkaConsumer<>(config, keyDeserializer, valueDeserializer));
+    return new KafkaReadStreamImpl<>(
+      vertx,
+      new org.apache.kafka.clients.consumer.KafkaConsumer<>(config, keyDeserializer, valueDeserializer),
+      options);
   }
 
   /**
@@ -217,11 +228,10 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
    *
    * @param vertx Vert.x instance to use
    * @param consumer  native Kafka consumer instance
-   * @return  an instance of the KafkaReadStream
+   * @return an instance of the KafkaReadStream
    */
   static <K, V> KafkaReadStream<K, V> create(Vertx vertx, Consumer<K, V> consumer) {
-    ConsumerTracer tracer = ConsumerTracer.create(vertx, (k, d) -> d);
-    return new KafkaReadStreamImpl<>(vertx.getOrCreateContext(), consumer, tracer);
+    return new KafkaReadStreamImpl<>(vertx, consumer, new KafkaClientOptions());
   }
 
   /**

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
@@ -23,6 +23,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.kafka.client.common.KafkaClientOptions;
+import io.vertx.kafka.client.common.tracing.ConsumerTracer;
 import io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl;
 import io.vertx.kafka.client.serialization.VertxSerdes;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -91,7 +92,8 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
    * @return  an instance of the KafkaReadStream
    */
   static <K, V> KafkaReadStream<K, V> create(Vertx vertx, Properties config) {
-    return create(vertx, new org.apache.kafka.clients.consumer.KafkaConsumer<>(config));
+    ConsumerTracer tracer = ConsumerTracer.create(vertx, config::getProperty);
+    return new KafkaReadStreamImpl<>(vertx.getOrCreateContext(), new org.apache.kafka.clients.consumer.KafkaConsumer<>(config), tracer);
   }
 
   /**
@@ -119,7 +121,8 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
    * @return  an instance of the KafkaReadStream
    */
   static <K, V> KafkaReadStream<K, V> create(Vertx vertx, Properties config, Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer) {
-    return create(vertx, new org.apache.kafka.clients.consumer.KafkaConsumer<>(config, keyDeserializer, valueDeserializer));
+    ConsumerTracer tracer = ConsumerTracer.create(vertx, config::getProperty);
+    return new KafkaReadStreamImpl<>(vertx.getOrCreateContext(), new org.apache.kafka.clients.consumer.KafkaConsumer<>(config, keyDeserializer, valueDeserializer), tracer);
   }
 
   /**
@@ -130,7 +133,8 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
    * @return  an instance of the KafkaReadStream
    */
   static <K, V> KafkaReadStream<K, V> create(Vertx vertx, Map<String, Object> config) {
-    return create(vertx, new org.apache.kafka.clients.consumer.KafkaConsumer<>(config));
+    ConsumerTracer tracer = ConsumerTracer.create(vertx, (k, d) -> (String)(config.getOrDefault(k, d)));
+    return new KafkaReadStreamImpl<>(vertx.getOrCreateContext(), new org.apache.kafka.clients.consumer.KafkaConsumer<>(config), tracer);
   }
 
   /**
@@ -216,7 +220,8 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
    * @return  an instance of the KafkaReadStream
    */
   static <K, V> KafkaReadStream<K, V> create(Vertx vertx, Consumer<K, V> consumer) {
-    return new KafkaReadStreamImpl<>(vertx.getOrCreateContext(), consumer);
+    ConsumerTracer tracer = ConsumerTracer.create(vertx, (k, d) -> d);
+    return new KafkaReadStreamImpl<>(vertx.getOrCreateContext(), consumer, tracer);
   }
 
   /**

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
@@ -21,7 +21,9 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
+import io.vertx.core.impl.ContextInternal;
 import io.vertx.kafka.client.common.impl.Helper;
+import io.vertx.kafka.client.common.tracing.ConsumerTracer;
 import io.vertx.kafka.client.consumer.KafkaReadStream;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
@@ -59,6 +61,7 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
   private final Context context;
   private final AtomicBoolean closed = new AtomicBoolean(true);
   private final Consumer<K, V> consumer;
+  private final ConsumerTracer tracer;
 
   private final AtomicBoolean consuming = new AtomicBoolean(false);
   private final AtomicLong demand = new AtomicLong(Long.MAX_VALUE);
@@ -98,9 +101,10 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
     }
   };
 
-  public KafkaReadStreamImpl(Context context, Consumer<K, V> consumer) {
+  public KafkaReadStreamImpl(Context context, Consumer<K, V> consumer, ConsumerTracer tracer) {
     this.context = context;
     this.consumer = consumer;
+    this.tracer = tracer;
   }
 
   private <T> void start(java.util.function.BiConsumer<Consumer<K, V>, Promise<T>> task, Handler<AsyncResult<T>> handler) {
@@ -227,10 +231,25 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
         }
 
         ConsumerRecord<K, V> next = this.current.next();
-        handler.handle(next);
+        this.tracedHandler(handler).handle(next);
       }
       this.schedule(0);
     }
+  }
+
+  private Handler<ConsumerRecord<K, V>> tracedHandler(Handler<ConsumerRecord<K, V>> handler) {
+    return this.tracer == null ? handler :
+      rec -> {
+        Context ctx = ((ContextInternal)this.context).duplicate();
+        ConsumerTracer.StartedSpan startedSpan = tracer.prepareMessageReceived(ctx, rec);
+        try {
+          handler.handle(rec);
+          startedSpan.finish(ctx);
+        } catch (Throwable t) {
+          startedSpan.fail(ctx, t);
+          throw t;
+        }
+      };
   }
 
   protected <T> void submitTask(java.util.function.BiConsumer<Consumer<K, V>, Promise<T>> task,

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
@@ -21,7 +21,9 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
+import io.vertx.kafka.client.common.KafkaClientOptions;
 import io.vertx.kafka.client.common.impl.Helper;
 import io.vertx.kafka.client.common.tracing.ConsumerTracer;
 import io.vertx.kafka.client.consumer.KafkaReadStream;
@@ -101,10 +103,11 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
     }
   };
 
-  public KafkaReadStreamImpl(Context context, Consumer<K, V> consumer, ConsumerTracer tracer) {
-    this.context = context;
+  public KafkaReadStreamImpl(Vertx vertx, Consumer<K, V> consumer, KafkaClientOptions options) {
     this.consumer = consumer;
-    this.tracer = tracer;
+    ContextInternal ctxInt = (ContextInternal) vertx.getOrCreateContext();
+    this.context = ctxInt;
+    this.tracer = ConsumerTracer.create(ctxInt.tracer(), options);
   }
 
   private <T> void start(java.util.function.BiConsumer<Consumer<K, V>, Promise<T>> task, Handler<AsyncResult<T>> handler) {

--- a/src/main/java/io/vertx/kafka/client/producer/KafkaWriteStream.java
+++ b/src/main/java/io/vertx/kafka/client/producer/KafkaWriteStream.java
@@ -170,7 +170,7 @@ public interface KafkaWriteStream<K, V> extends WriteStream<ProducerRecord<K, V>
    * @param producer  native Kafka producer instance
    */
   static <K, V> KafkaWriteStream<K, V> create(Vertx vertx, Producer<K, V> producer) {
-    return new KafkaWriteStreamImpl<>(vertx.getOrCreateContext(), producer);
+    return KafkaWriteStreamImpl.create(vertx, producer);
   }
 
   @Fluent

--- a/src/test/java/io/vertx/kafka/client/common/tracing/TracingTest.java
+++ b/src/test/java/io/vertx/kafka/client/common/tracing/TracingTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2020 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertx.kafka.client.common.tracing;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.spi.tracing.TagExtractor;
+import io.vertx.core.spi.tracing.VertxTracer;
+import io.vertx.core.tracing.TracingOptions;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.kafka.client.consumer.KafkaReadStream;
+import io.vertx.kafka.client.producer.KafkaProducer;
+import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import io.vertx.kafka.client.producer.KafkaWriteStream;
+import io.vertx.kafka.client.producer.impl.KafkaProducerImpl;
+import io.vertx.kafka.client.tests.KafkaClusterTestBase;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.BiConsumer;
+
+/**
+ * Tracing tests
+ */
+public class TracingTest extends KafkaClusterTestBase {
+
+  private Vertx vertx;
+  private KafkaWriteStream<String, String> producer;
+  private KafkaReadStream<String, String> consumer;
+  private TestTracer tracer;
+
+  @Before
+  public void beforeTest(TestContext ctx) {
+    tracer = new TestTracer(ctx);
+    vertx = Vertx.vertx(new VertxOptions().setTracingOptions(new TracingOptions().setFactory(tracingOptions -> tracer)));
+  }
+
+  @After
+  public void afterTest(TestContext ctx) {
+    close(ctx, producer);
+    close(ctx, consumer);
+    vertx.close(ctx.asyncAssertSuccess());
+  }
+
+  @Test
+  public void testTracing(TestContext ctx) {
+    String topicName = "TestTracing";
+    Properties pConf = kafkaCluster.useTo().getProducerProperties("testTracing_producer");
+    pConf.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    pConf.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    producer = producer(vertx, pConf);
+    producer.exceptionHandler(ctx::fail);
+    KafkaProducer<String, String> producer = new KafkaProducerImpl<>(this.vertx, this.producer);
+
+    Properties cConf = kafkaCluster.useTo().getConsumerProperties("testTracing_consumer", "testTracing_consumer", OffsetResetStrategy.EARLIEST);
+    cConf.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    cConf.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    consumer = KafkaReadStream.create(vertx, cConf);
+    consumer.exceptionHandler(ctx::fail);
+    consumer.handler(rec -> {});
+    consumer.subscribe(Collections.singleton(topicName));
+
+    int numMessages = 1000;
+    tracer.init(topicName, numMessages, numMessages);
+    for (int i = 0; i < numMessages; i++) {
+      producer.write(KafkaProducerRecord.create(topicName, "key-" + i, "value-" + i, 0));
+    }
+    tracer.assertAllDone(0);
+  }
+
+  @Test
+  public void testTracingFailure(TestContext ctx) {
+    Properties pConf = kafkaCluster.useTo().getProducerProperties("testTracing_producer");
+    pConf.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    pConf.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+    tracer.init("topic", 2, 0);
+    Date invalidValue = new Date();
+    KafkaProducer p = KafkaProducer.create(vertx, pConf);
+    p.write(KafkaProducerRecord.create("topic", "key", "valid string"));
+    p.write(KafkaProducerRecord.create("topic", "key", invalidValue));
+    tracer.assertAllDone(1);
+  }
+
+  private static class TestTracer implements VertxTracer<String, String> {
+    private final TestContext ctx;
+    private String topic;
+    private Async done;
+    private LongAdder failuresCount;
+
+    private TestTracer(TestContext ctx) {
+      this.ctx = ctx;
+    }
+
+    @Override
+    public <R> String receiveRequest(Context context, R request, String operation, Iterable<Map.Entry<String, String>> headers, TagExtractor<R> tagExtractor) {
+      Map<String, String> tags = tagExtractor.extract(request);
+      ctx.assertEquals("kafka_receive", operation);
+      ctx.assertEquals("consumer", tags.get("span.kind"));
+      ctx.assertEquals("localhost:9092", tags.get("peer.address"));
+      ctx.assertEquals("localhost", tags.get("peer.hostname"));
+      ctx.assertEquals("9092", tags.get("peer.port"));
+      ctx.assertEquals(topic, tags.get("message_bus.destination"));
+      ctx.assertEquals("kafka", tags.get("peer.service"));
+      done.countDown();
+      return "SPAN-CONSUMER";
+    }
+
+    @Override
+    public <R> void sendResponse(Context context, R response, String payload, Throwable failure, TagExtractor<R> tagExtractor) {
+      ctx.assertEquals("SPAN-CONSUMER", payload);
+      done.countDown();
+    }
+
+    @Override
+    public <R> String sendRequest(Context context, R request, String operation, BiConsumer<String, String> headers, TagExtractor<R> tagExtractor) {
+      Map<String, String> tags = tagExtractor.extract(request);
+      ctx.assertEquals("kafka_send", operation);
+      ctx.assertEquals("producer", tags.get("span.kind"));
+      ctx.assertEquals("localhost:9092", tags.get("peer.address"));
+      ctx.assertEquals("localhost", tags.get("peer.hostname"));
+      ctx.assertEquals("9092", tags.get("peer.port"));
+      ctx.assertEquals(topic, tags.get("message_bus.destination"));
+      ctx.assertEquals("kafka", tags.get("peer.service"));
+      done.countDown();
+      return "SPAN-PRODUCER";
+    }
+
+    @Override
+    public <R> void receiveResponse(Context context, R response, String payload, Throwable failure, TagExtractor<R> tagExtractor) {
+      ctx.assertEquals("SPAN-PRODUCER", payload);
+      if (failure != null) {
+        failuresCount.increment();
+      }
+      done.countDown();
+    }
+
+    void init(String topic, int sent, int received) {
+      done = ctx.async(2 * sent + 2 * received);
+      this.topic = topic;
+      failuresCount = new LongAdder();
+    }
+
+    void assertAllDone(int expectedFailures) {
+      done.await(2000);
+      ctx.assertEquals(expectedFailures, failuresCount.intValue());
+    }
+  }
+}

--- a/src/test/java/io/vertx/kafka/client/common/tracing/TracingTest.java
+++ b/src/test/java/io/vertx/kafka/client/common/tracing/TracingTest.java
@@ -21,8 +21,10 @@ import io.vertx.core.VertxOptions;
 import io.vertx.core.spi.tracing.TagExtractor;
 import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.tracing.TracingOptions;
+import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.kafka.client.common.KafkaClientOptions;
 import io.vertx.kafka.client.consumer.KafkaReadStream;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
@@ -108,18 +110,92 @@ public class TracingTest extends KafkaClusterTestBase {
     tracer.assertAllDone(1);
   }
 
+  @Test
+  public void testTracingIgnoreConsumer(TestContext ctx) {
+    String topicName = "TestTracingIgnoreC";
+    KafkaClientOptions options = new KafkaClientOptions()
+      .setConfig(mapConfig(kafkaCluster.useTo().getProducerProperties("testTracing_producer")))
+      .setConfig(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+      .setConfig(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+      .setTracingPolicy(TracingPolicy.ALWAYS);
+
+    producer = producer(vertx, options);
+    producer.exceptionHandler(ctx::fail);
+    KafkaProducer<String, String> producer = new KafkaProducerImpl<>(this.vertx, this.producer);
+
+    options = new KafkaClientOptions()
+      .setConfig(mapConfig(kafkaCluster.useTo().getConsumerProperties("testTracing_consumer", "testTracing_consumer", OffsetResetStrategy.EARLIEST)))
+      .setConfig(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+      .setConfig(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+      .setTracingPolicy(TracingPolicy.IGNORE);
+    consumer = KafkaReadStream.create(vertx, options);
+    consumer.exceptionHandler(ctx::fail);
+
+    int numMessages = 10;
+    Async done = ctx.async(numMessages);
+    consumer.handler(rec -> done.countDown());
+    consumer.subscribe(Collections.singleton(topicName));
+
+    tracer.init(topicName, numMessages, 0);
+    for (int i = 0; i < numMessages; i++) {
+      producer.write(KafkaProducerRecord.create(topicName, "key-" + i, "value-" + i, 0));
+    }
+    tracer.assertAllDone(0);
+    done.awaitSuccess(10000);
+  }
+
+  @Test
+  public void testTracingIgnoreProducer(TestContext ctx) {
+    String topicName = "TestTracingIgnoreP";
+    KafkaClientOptions options = new KafkaClientOptions()
+      .setConfig(mapConfig(kafkaCluster.useTo().getProducerProperties("testTracing_producer")))
+      .setConfig(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+      .setConfig(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+      .setTracingPolicy(TracingPolicy.IGNORE);
+
+    producer = producer(vertx, options);
+    producer.exceptionHandler(ctx::fail);
+    KafkaProducer<String, String> producer = new KafkaProducerImpl<>(this.vertx, this.producer);
+
+    options = new KafkaClientOptions()
+      .setConfig(mapConfig(kafkaCluster.useTo().getConsumerProperties("testTracing_consumer", "testTracing_consumer", OffsetResetStrategy.EARLIEST)))
+      .setConfig(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+      .setConfig(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+      .setTracingPolicy(TracingPolicy.ALWAYS);
+    consumer = KafkaReadStream.create(vertx, options);
+    consumer.exceptionHandler(ctx::fail);
+
+    int numMessages = 10;
+    Async done = ctx.async(numMessages);
+    consumer.handler(rec -> done.countDown());
+    consumer.subscribe(Collections.singleton(topicName));
+
+    tracer.init(topicName, 0, numMessages);
+    for (int i = 0; i < numMessages; i++) {
+      producer.write(KafkaProducerRecord.create(topicName, "key-" + i, "value-" + i, 0));
+    }
+    tracer.assertAllDone(0);
+    done.awaitSuccess(10000);
+  }
+
   private static class TestTracer implements VertxTracer<String, String> {
     private final TestContext ctx;
     private String topic;
     private Async done;
     private LongAdder failuresCount;
+    private LongAdder sentCount;
+    private LongAdder receivedCount;
 
     private TestTracer(TestContext ctx) {
       this.ctx = ctx;
     }
 
     @Override
-    public <R> String receiveRequest(Context context, R request, String operation, Iterable<Map.Entry<String, String>> headers, TagExtractor<R> tagExtractor) {
+    public <R> String receiveRequest(Context context, TracingPolicy policy, R request, String operation, Iterable<Map.Entry<String, String>> headers, TagExtractor<R> tagExtractor) {
+      receivedCount.decrement();
+      if (receivedCount.intValue() < 0) {
+        ctx.fail("Unexpected call to receiveRequest");
+      }
       Map<String, String> tags = tagExtractor.extract(request);
       ctx.assertEquals("kafka_receive", operation);
       ctx.assertEquals("consumer", tags.get("span.kind"));
@@ -139,7 +215,11 @@ public class TracingTest extends KafkaClusterTestBase {
     }
 
     @Override
-    public <R> String sendRequest(Context context, R request, String operation, BiConsumer<String, String> headers, TagExtractor<R> tagExtractor) {
+    public <R> String sendRequest(Context context, TracingPolicy policy, R request, String operation, BiConsumer<String, String> headers, TagExtractor<R> tagExtractor) {
+      sentCount.decrement();
+      if (sentCount.intValue() < 0) {
+        ctx.fail("Unexpected call to sendRequest");
+      }
       Map<String, String> tags = tagExtractor.extract(request);
       ctx.assertEquals("kafka_send", operation);
       ctx.assertEquals("producer", tags.get("span.kind"));
@@ -162,6 +242,10 @@ public class TracingTest extends KafkaClusterTestBase {
     }
 
     void init(String topic, int sent, int received) {
+      sentCount = new LongAdder();
+      sentCount.add(sent);
+      receivedCount = new LongAdder();
+      receivedCount.add(received);
       done = ctx.async(2 * sent + 2 * received);
       this.topic = topic;
       failuresCount = new LongAdder();
@@ -170,6 +254,8 @@ public class TracingTest extends KafkaClusterTestBase {
     void assertAllDone(int expectedFailures) {
       done.await(2000);
       ctx.assertEquals(expectedFailures, failuresCount.intValue());
+      ctx.assertEquals(0, sentCount.intValue());
+      ctx.assertEquals(0, receivedCount.intValue());
     }
   }
 }

--- a/src/test/java/io/vertx/kafka/client/tests/KafkaTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/KafkaTestBase.java
@@ -21,6 +21,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.kafka.client.common.KafkaClientOptions;
 import io.vertx.kafka.client.consumer.KafkaReadStream;
 import io.vertx.kafka.client.producer.KafkaWriteStream;
 import org.apache.kafka.clients.producer.Producer;
@@ -57,12 +58,15 @@ public class KafkaTestBase {
     }
   }
 
-  static Map<String, String> mapConfig(Properties cfg) {
-    Map<String ,String> map = new HashMap<>();
-    cfg.forEach((k, v) -> map.put("" + k, "" + v));
+  public static Map<String, Object> mapConfig(Properties cfg) {
+    Map<String, Object> map = new HashMap<>();
+    cfg.forEach((k, v) -> map.put("" + k, v));
     return map;
   }
 
+  public static <K, V> KafkaWriteStream<K, V> producer(Vertx vertx, KafkaClientOptions opts) {
+    return KafkaWriteStream.create(vertx, opts);
+  }
 
   public static <K, V> KafkaWriteStream<K, V> producer(Vertx vertx, Properties config) {
     return KafkaWriteStream.create(vertx, config);

--- a/src/test/java/io/vertx/kafka/client/tests/KafkaTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/KafkaTestBase.java
@@ -45,13 +45,13 @@ public class KafkaTestBase {
     }
   }
 
-  static void close(TestContext ctx, KafkaWriteStream<?, ?> producer) {
+  public static void close(TestContext ctx, KafkaWriteStream<?, ?> producer) {
     if (producer != null) {
       close(ctx, handler -> producer.close(2000L, handler));
     }
   }
 
-  static void close(TestContext ctx, KafkaReadStream<?, ?> consumer) {
+  public static void close(TestContext ctx, KafkaReadStream<?, ?> consumer) {
     if (consumer != null) {
       KafkaTestBase.close(ctx, consumer::close);
     }
@@ -64,7 +64,7 @@ public class KafkaTestBase {
   }
 
 
-  static <K, V> KafkaWriteStream<K, V> producer(Vertx vertx, Properties config) {
+  public static <K, V> KafkaWriteStream<K, V> producer(Vertx vertx, Properties config) {
     return KafkaWriteStream.create(vertx, config);
   }
 


### PR DESCRIPTION
Use the vertx-tracing SPI to create spans upon Kafka sending / receiving messages, whenever a tracer is configured.

Fixes https://github.com/vert-x3/vertx-kafka-client/issues/184
