### PR TITLE
expose listOffsets at KafkaAdminClient

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -165,6 +165,22 @@ Set if consumer group is simple or not
 ^|Name | Type ^| Description
 |===
 
+[[ListOffsetsResultInfo]]
+== ListOffsetsResultInfo
+
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[offset]]`@offset`|`Number (long)`|+++
+Set the offset
++++
+|[[timestamp]]`@timestamp`|`Number (long)`|+++
+Set the timestamp
++++
+|===
+
 [[MemberAssignment]]
 == MemberAssignment
 
@@ -303,6 +319,19 @@ Set the offset
 +++
 |[[timestamp]]`@timestamp`|`Number (long)`|+++
 Set the timestamp
++++
+|===
+
+[[OffsetSpec]]
+== OffsetSpec
+
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[spec]]`@spec`|`Number (long)`|+++
+Set the offset spec
 +++
 |===
 

--- a/src/main/generated/io/vertx/kafka/admin/ListOffsetsResultInfoConverter.java
+++ b/src/main/generated/io/vertx/kafka/admin/ListOffsetsResultInfoConverter.java
@@ -1,0 +1,41 @@
+package io.vertx.kafka.admin;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.kafka.admin.ListOffsetsResultInfo}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.kafka.admin.ListOffsetsResultInfo} original class using Vert.x codegen.
+ */
+public class ListOffsetsResultInfoConverter {
+
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ListOffsetsResultInfo obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "offset":
+          if (member.getValue() instanceof Number) {
+            obj.setOffset(((Number)member.getValue()).longValue());
+          }
+          break;
+        case "timestamp":
+          if (member.getValue() instanceof Number) {
+            obj.setTimestamp(((Number)member.getValue()).longValue());
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(ListOffsetsResultInfo obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(ListOffsetsResultInfo obj, java.util.Map<String, Object> json) {
+    json.put("offset", obj.getOffset());
+    json.put("timestamp", obj.getTimestamp());
+  }
+}

--- a/src/main/generated/io/vertx/kafka/admin/OffsetSpecConverter.java
+++ b/src/main/generated/io/vertx/kafka/admin/OffsetSpecConverter.java
@@ -1,0 +1,35 @@
+package io.vertx.kafka.admin;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.kafka.admin.OffsetSpec}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.kafka.admin.OffsetSpec} original class using Vert.x codegen.
+ */
+public class OffsetSpecConverter {
+
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, OffsetSpec obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "spec":
+          if (member.getValue() instanceof Number) {
+            obj.setSpec(((Number)member.getValue()).longValue());
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(OffsetSpec obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(OffsetSpec obj, java.util.Map<String, Object> json) {
+    json.put("spec", obj.getSpec());
+  }
+}

--- a/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
+++ b/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
@@ -26,7 +26,6 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.kafka.admin.impl.KafkaAdminClientImpl;
-import io.vertx.kafka.client.common.ConfigResource;
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.OffsetAndMetadata;
 import java.util.HashMap;
@@ -34,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import org.apache.kafka.clients.admin.AdminClient;
 
 /**
  * Vert.x Kafka Admin client implementation
@@ -257,6 +255,21 @@ public interface KafkaAdminClient {
    * Like {@link #deleteConsumerGroupOffsets(String, Set, Handler)} but returns a {@code Future} of the asynchronous result
    */
   Future<Void> deleteConsumerGroupOffsets(String groupId, Set<TopicPartition> partitions);
+
+  /**
+   * List the offsets available for a set of partitions.
+   *
+   * @param topicPartitionOffsets The options to use when listing the partition offsets.
+   * @param completionHandler handler called on operation completed with the partition offsets
+   */
+  @GenIgnore
+  void listOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets, Handler<AsyncResult<Map<TopicPartition, ListOffsetsResultInfo>>> completionHandler);
+
+  /**
+   * Like {@link #listOffsets(Map<TopicPartition, OffsetSpec>, Handler)} but returns a {@code Future} of the asynchronous result
+   */
+  @GenIgnore
+  Future<Map<TopicPartition, ListOffsetsResultInfo>> listOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets);
 
   /**
    * Close the admin client

--- a/src/main/java/io/vertx/kafka/admin/ListOffsetsResultInfo.java
+++ b/src/main/java/io/vertx/kafka/admin/ListOffsetsResultInfo.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.kafka.admin;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.Optional;
+
+@DataObject(generateConverter = true)
+public class ListOffsetsResultInfo {
+  private long offset;
+  private long timestamp;
+  private Optional<Integer> leaderEpoch;
+
+  /**
+   * Constructor
+   *
+   * @param offset the offset
+   * @param timestamp the timestamp
+   * @param leaderEpoch the leader epoch
+   */
+  public ListOffsetsResultInfo(long offset, long timestamp, Optional<Integer> leaderEpoch) {
+    this.offset = offset;
+    this.timestamp = timestamp;
+    this.leaderEpoch = leaderEpoch;
+  }
+
+
+  /**
+   * Constructor (from JSON representation)
+   *
+   * @param json  JSON representation
+   */
+  public ListOffsetsResultInfo(JsonObject json) {
+    ListOffsetsResultInfoConverter.fromJson(json, this);
+  }
+
+  /**
+   * @return the offset
+   */
+  public long getOffset() {
+    return offset;
+  }
+
+  /**
+   * @return the timestamp
+   */
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  /**
+   * @return the leader epoch
+   */
+  public Optional<Integer> getLeaderEpoch() {
+    return leaderEpoch;
+  }
+
+  /**
+   * Set the offset
+   *
+   * @param offset the offset
+   * @return current instance of the class to be fluent
+   */
+  public ListOffsetsResultInfo setOffset(long offset) {
+    this.offset = offset;
+    return this;
+  }
+  /**
+   * Set the timestamp
+   *
+   * @param timestamp the timestamp
+   * @return current instance of the class to be fluent
+   */
+  public ListOffsetsResultInfo setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+    return this;
+  }
+  /**
+   * Set the leader epoch
+   *
+   * @param leaderEpoch the leader epoch
+   * @return current instance of the class to be fluent
+   */
+  public ListOffsetsResultInfo setLeaderEpoch(Optional<Integer> leaderEpoch) {
+    this.leaderEpoch = leaderEpoch;
+    return this;
+  }
+
+  /**
+   * Convert object to JSON representation
+   *
+   * @return  JSON representation
+   */
+  public JsonObject toJson() {
+
+    JsonObject json = new JsonObject();
+    ListOffsetsResultInfoConverter.toJson(this, json);
+    return json;
+  }
+
+  @Override
+  public String toString() {
+    return "ListOffsetsResultInfo{" +
+      "offset=" + this.offset +
+      ",timestamp=" + this.timestamp +
+      (this.leaderEpoch.isPresent()? ",leaderEpoch=" + this.leaderEpoch.get(): "") +
+      "}";
+  }
+}

--- a/src/main/java/io/vertx/kafka/admin/OffsetSpec.java
+++ b/src/main/java/io/vertx/kafka/admin/OffsetSpec.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.kafka.admin;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+@DataObject(generateConverter = true)
+public class OffsetSpec {
+  public final static OffsetSpec EARLIEST = new OffsetSpec(-2L);
+  public final static OffsetSpec LATEST = new OffsetSpec(-1L);
+  public final static OffsetSpec TIMESTAMP(long timestamp) {
+    return new OffsetSpec(timestamp);
+  }
+
+  private long spec;
+
+  /**
+   * Constructor
+   *
+   * @param spec the offset spec Spec.EARLIEST, Spec.LATEST, or a Spec.TIMESTAMP(long) value
+   */
+  public OffsetSpec(long spec) {
+    this.spec = spec;
+  }
+
+  /**
+   * Constructor (from JSON representation)
+   *
+   * @param json  JSON representation
+   */
+  public OffsetSpec(JsonObject json) {
+    OffsetSpecConverter.fromJson(json, this);
+  }
+
+  /**
+   * @return offset spec
+   */
+  public long getSpec() {
+    return spec;
+  }
+
+  /**
+   * Set the offset spec
+   *
+   * @param spec the offset spec
+   * @return current instance of the class to be fluent
+   */
+  public OffsetSpec setSpec(long spec) {
+    this.spec = spec;
+    return this;
+  }
+
+  /**
+   * Convert object to JSON representation
+   *
+   * @return  JSON representation
+   */
+  public JsonObject toJson() {
+
+    JsonObject json = new JsonObject();
+    OffsetSpecConverter.toJson(this, json);
+    return json;
+  }
+
+  @Override
+  public String toString() {
+    String value;
+    if (EARLIEST == this) {
+      value = "EARLIEST";
+    } else if (LATEST == this) {
+      value = "LATEST";
+    } else {
+      value = String.format("TIMESTAMP(%d)", this.spec);
+    }
+
+    return "OffsetSpec{" +
+      "spec=" + value +
+      "}";
+  }
+}

--- a/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
+++ b/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
@@ -21,8 +21,10 @@ import io.vertx.kafka.admin.Config;
 import io.vertx.kafka.admin.ConfigEntry;
 import io.vertx.kafka.admin.ConsumerGroupListing;
 import io.vertx.kafka.admin.ListConsumerGroupOffsetsOptions;
+import io.vertx.kafka.admin.ListOffsetsResultInfo;
 import io.vertx.kafka.admin.MemberAssignment;
 import io.vertx.kafka.admin.NewTopic;
+import io.vertx.kafka.admin.OffsetSpec;
 import io.vertx.kafka.client.common.ConfigResource;
 import io.vertx.kafka.client.common.Node;
 import io.vertx.kafka.client.consumer.OffsetAndTimestamp;
@@ -222,5 +224,26 @@ public class Helper {
 
   public static Set<org.apache.kafka.common.TopicPartition> toTopicPartitionSet(Set<TopicPartition> partitions) {
     return partitions.stream().map(Helper::to).collect(Collectors.toSet());
+  }
+
+  public static org.apache.kafka.clients.admin.OffsetSpec to(OffsetSpec os) {
+    if (os.EARLIEST == os) {
+      return org.apache.kafka.clients.admin.OffsetSpec.earliest();
+    } else if (os.LATEST == os) {
+      return org.apache.kafka.clients.admin.OffsetSpec.latest();
+    } else {
+      return org.apache.kafka.clients.admin.OffsetSpec.forTimestamp(os.getSpec());
+    }
+  }
+
+  public static Map<org.apache.kafka.common.TopicPartition, org.apache.kafka.clients.admin.OffsetSpec> toTopicPartitionOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets) {
+    return topicPartitionOffsets.entrySet().stream().collect(Collectors.toMap(
+      e -> new org.apache.kafka.common.TopicPartition(e.getKey().getTopic(), e.getKey().getPartition()),
+      e -> to(e.getValue())
+    ));
+  }
+
+  public static ListOffsetsResultInfo from(org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo lori) {
+    return new ListOffsetsResultInfo(lori.offset(), lori.timestamp(), lori.leaderEpoch());
   }
 }

--- a/src/test/java/io/vertx/kafka/client/tests/AdminClientTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/AdminClientTest.java
@@ -39,9 +39,11 @@ import java.util.stream.Collectors;
 import io.vertx.kafka.admin.Config;
 import io.vertx.kafka.admin.ConfigEntry;
 import io.vertx.kafka.admin.ConsumerGroupDescription;
+import io.vertx.kafka.admin.ListOffsetsResultInfo;
 import io.vertx.kafka.admin.MemberAssignment;
 import io.vertx.kafka.admin.MemberDescription;
 import io.vertx.kafka.admin.NewTopic;
+import io.vertx.kafka.admin.OffsetSpec;
 import io.vertx.kafka.admin.TopicDescription;
 import io.vertx.kafka.client.common.ConfigResource;
 import io.vertx.kafka.client.common.Node;
@@ -107,7 +109,7 @@ public class AdminClientTest extends KafkaClusterTestBase {
     vertx.setTimer(1000, t -> {
       adminClient.listTopics(ctx.asyncAssertSuccess(res ->{
         ctx.assertTrue(res.containsAll(topics), "Was expecting topics " + topics + " to be in " + res);
-        
+
         adminClient.close();
         async.complete();
       }));
@@ -564,4 +566,49 @@ public class AdminClientTest extends KafkaClusterTestBase {
     }));
   }
 
+  @Test
+  public void testListOffsets(TestContext ctx) {
+    final String topicName = "list-offsets-topic";
+    kafkaCluster.createTopic(topicName, 1, 1);
+
+    Async producerAsync = ctx.async();
+    kafkaCluster.useTo().produceIntegers(topicName, 6, 1, producerAsync::complete);
+    producerAsync.awaitSuccess(10000);
+
+    final KafkaAdminClient adminClient = KafkaAdminClient.create(this.vertx, config);
+    final TopicPartition topicPartition0 = new TopicPartition().setTopic(topicName).setPartition(0);
+
+    // BeginOffsets
+    Map<TopicPartition, OffsetSpec> topicPartitionBeginOffsets = Collections.singletonMap(topicPartition0, OffsetSpec.EARLIEST);
+    final Async async1 = ctx.async();
+    adminClient.listOffsets(topicPartitionBeginOffsets, ctx.asyncAssertSuccess(listOffsets -> {
+      ListOffsetsResultInfo offsets = listOffsets.get(topicPartition0);
+      ctx.assertNotNull(offsets);
+      ctx.assertEquals(0L, offsets.getOffset());
+      async1.complete();
+    }));
+
+    // EndOffsets
+    Map<TopicPartition, OffsetSpec> topicPartitionEndOffsets = Collections.singletonMap(topicPartition0, OffsetSpec.LATEST);
+    final Async async2 = ctx.async();
+    adminClient.listOffsets(topicPartitionEndOffsets, ctx.asyncAssertSuccess(listOffsets -> {
+      ListOffsetsResultInfo offsets = listOffsets.get(topicPartition0);
+      ctx.assertNotNull(offsets);
+      ctx.assertEquals(6L, offsets.getOffset());
+      adminClient.close();
+      async2.complete();
+    }));
+  }
+
+  @Test
+  public void testListOffsetsNoTopic(TestContext ctx) {
+    final String topicName = "list-offsets-notopic";
+
+    final KafkaAdminClient adminClient = KafkaAdminClient.create(this.vertx, config);
+    final TopicPartition topicPartition0 = new TopicPartition().setTopic(topicName).setPartition(0);
+
+    // BeginOffsets of a non existent topic-partition
+    Map<TopicPartition, OffsetSpec> topicPartitionBeginOffsets = Collections.singletonMap(topicPartition0, OffsetSpec.EARLIEST);
+    adminClient.listOffsets(topicPartitionBeginOffsets, ctx.asyncAssertFailure());
+  }
 }


### PR DESCRIPTION
Signed-off-by: Aki Yoshida <elakito@gmail.com>

Motivation:

To support the consumer-independent getOffsets operation in strimzi-kafka-bridge, kafka-client's listOffsets needs to be exposed over vertx-kafka-client's KafkaAdminClient. This PR adds listOffsets to KafkaAdminClient. 

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
