### PR TITLE
Use incrementalAlterConfig

### DIFF
--- a/src/main/java/io/vertx/kafka/admin/impl/KafkaAdminClientImpl.java
+++ b/src/main/java/io/vertx/kafka/admin/impl/KafkaAdminClientImpl.java
@@ -234,7 +234,7 @@ public class KafkaAdminClientImpl implements KafkaAdminClient {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
     Promise<Void> promise = ctx.promise();
 
-    AlterConfigsResult alterConfigsResult = this.adminClient.alterConfigs(Helper.toConfigMaps(configs));
+    AlterConfigsResult alterConfigsResult = this.adminClient.incrementalAlterConfigs(Helper.toConfigMaps(configs));
     alterConfigsResult.all().whenComplete((v, ex) -> {
 
       if (ex == null) {

--- a/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
+++ b/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
@@ -31,8 +31,8 @@ import io.vertx.kafka.client.consumer.OffsetAndTimestamp;
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.OffsetAndMetadata;
 import io.vertx.kafka.client.producer.RecordMetadata;
+import org.apache.kafka.clients.admin.AlterConfigOp;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -172,19 +172,17 @@ public class Helper {
     return configResources.stream().map(Helper::to).collect(Collectors.toList());
   }
 
-  public static Collection<org.apache.kafka.clients.admin.ConfigEntry> toConfigEntryList(List<ConfigEntry> configEntries) {
-    return configEntries.stream().map(Helper::to).collect(Collectors.toList());
-  }
-
   public static org.apache.kafka.clients.admin.ConfigEntry to(ConfigEntry configEntry) {
     return new org.apache.kafka.clients.admin.ConfigEntry(configEntry.getName(), configEntry.getValue());
   }
 
-  public static Map<org.apache.kafka.common.config.ConfigResource, org.apache.kafka.clients.admin.Config> toConfigMaps(Map<ConfigResource, Config> configs) {
+  public static Map<org.apache.kafka.common.config.ConfigResource, Collection<AlterConfigOp>> toConfigMaps(Map<ConfigResource, Config> configs) {
+
     return configs.entrySet().stream().collect(Collectors.toMap(
-      e -> new org.apache.kafka.common.config.ConfigResource(e.getKey().getType(), e.getKey().getName()),
-      e -> new org.apache.kafka.clients.admin.Config(Helper.toConfigEntryList(e.getValue().getEntries()))
-    ));
+            e -> new org.apache.kafka.common.config.ConfigResource(e.getKey().getType(), e.getKey().getName()),
+            e -> e.getValue().getEntries().stream().map(
+                    v -> new AlterConfigOp(to(v), AlterConfigOp.OpType.SET)).collect(Collectors.toList())));
+
   }
 
   public static ConfigEntry from(org.apache.kafka.clients.admin.ConfigEntry configEntry) {


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

Motivation:

Currently the procject uses deprecated [alterConfigs](https://kafka.apache.org/26/javadoc/org/apache/kafka/clients/admin/Admin.html#alterConfigs-java.util.Map-). This PR uses [incrementalAlterConfigs](https://kafka.apache.org/26/javadoc/org/apache/kafka/clients/admin/Admin.html#incrementalAlterConfigs-java.util.Map-org.apache.kafka.clients.admin.AlterConfigsOptions-) instead.
