### PR TITLE
Support altering consumer group offsets (3.9 backport)

### DIFF
--- a/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
+++ b/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
@@ -192,6 +192,15 @@ public interface KafkaAdminClient {
   void deleteConsumerGroupOffsets(String groupId, Set<TopicPartition> partitions, Handler<AsyncResult<Void>> completionHandler);
 
   /**
+   * Alter committed offsets for a set of partitions in a consumer group.
+   *
+   * @param groupId The group id of the group whose offsets will be altered
+   * @param offsets The map of offsets in the consumer group which will be altered
+   */
+  @GenIgnore
+  void alterConsumerGroupOffsets(String groupId, Map<TopicPartition, OffsetAndMetadata> offsets, Handler<AsyncResult<Void>> completionHandler);
+
+  /**
    * List the offsets available for a set of partitions.
    *
    * @param topicPartitionOffsets The options to use when listing the partition offsets.

--- a/src/main/java/io/vertx/kafka/admin/impl/KafkaAdminClientImpl.java
+++ b/src/main/java/io/vertx/kafka/admin/impl/KafkaAdminClientImpl.java
@@ -44,6 +44,7 @@ import io.vertx.kafka.client.common.TopicPartitionInfo;
 import io.vertx.kafka.client.common.impl.Helper;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
+import org.apache.kafka.clients.admin.AlterConsumerGroupOffsetsResult;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteConsumerGroupOffsetsResult;
 import org.apache.kafka.clients.admin.DeleteConsumerGroupsResult;
@@ -287,6 +288,18 @@ public class KafkaAdminClientImpl implements KafkaAdminClient {
   public void deleteConsumerGroupOffsets(String groupId, Set<TopicPartition> partitions, Handler<AsyncResult<Void>> completionHandler) {
     DeleteConsumerGroupOffsetsResult deleteConsumerGroupOffsetsResult = this.adminClient.deleteConsumerGroupOffsets(groupId, Helper.toTopicPartitionSet(partitions));
     deleteConsumerGroupOffsetsResult.all().whenComplete((v, ex) -> {
+      if (ex == null) {
+        completionHandler.handle(Future.succeededFuture());
+      } else {
+        completionHandler.handle(Future.failedFuture(ex));
+      }
+    });
+  }
+
+  @Override
+  public void alterConsumerGroupOffsets(String groupId, Map<TopicPartition, OffsetAndMetadata> offsets, Handler<AsyncResult<Void>> completionHandler) {
+    AlterConsumerGroupOffsetsResult alterConsumerGroupOffsetsResult = this.adminClient.alterConsumerGroupOffsets(groupId, Helper.to(offsets));
+    alterConsumerGroupOffsetsResult.all().whenComplete((v, ex) -> {
       if (ex == null) {
         completionHandler.handle(Future.succeededFuture());
       } else {


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

Motivation:
same as in https://github.com/vert-x3/vertx-kafka-client/pull/197