### PR TITLE
Support creating new partitions in the topic

### DIFF
--- a/src/main/generated/io/vertx/kafka/admin/NewPartitionsConverter.java
+++ b/src/main/generated/io/vertx/kafka/admin/NewPartitionsConverter.java
@@ -1,0 +1,35 @@
+package io.vertx.kafka.admin;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.kafka.admin.NewPartitions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.kafka.admin.NewPartitions} original class using Vert.x codegen.
+ */
+public class NewPartitionsConverter {
+
+
+  public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, NewPartitions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "totalCount":
+          if (member.getValue() instanceof Number) {
+            obj.setTotalCount(((Number)member.getValue()).intValue());
+          }
+          break;
+      }
+    }
+  }
+
+  public static void toJson(NewPartitions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+  public static void toJson(NewPartitions obj, java.util.Map<String, Object> json) {
+    json.put("totalCount", obj.getTotalCount());
+  }
+}

--- a/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
+++ b/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
@@ -132,8 +132,13 @@ public interface KafkaAdminClient {
    * @param partitions partitions to create
    * @param completionHandler handler called on operation completed
    */
-  @GenIgnore
   void createPartitions(Map<String, io.vertx.kafka.admin.NewPartitions> partitions, Handler<AsyncResult<Void>> completionHandler);
+
+  /**
+   * Like {@link #createPartitions(Map, Handler)} but returns a {@code Future} of the asynchronous result
+   * @param partitions
+   */
+  Future<Void> createPartitions(Map<String, io.vertx.kafka.admin.NewPartitions> partitions);
 
 
   /**

--- a/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
+++ b/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
@@ -127,6 +127,16 @@ public interface KafkaAdminClient {
   Future<Void> deleteTopics(List<String> topicNames);
 
   /**
+   * Creates a batch of new partitions in the Kafka topic
+   *
+   * @param partitions partitions to create
+   * @param completionHandler handler called on operation completed
+   */
+  @GenIgnore
+  void createPartitions(Map<String, io.vertx.kafka.admin.NewPartitions> partitions, Handler<AsyncResult<Void>> completionHandler);
+
+
+  /**
    * Get the configuration for the specified resources with the default options
    *
    * @param configResources the resources (topic and broker resource types are currently supported)

--- a/src/main/java/io/vertx/kafka/admin/NewPartitions.java
+++ b/src/main/java/io/vertx/kafka/admin/NewPartitions.java
@@ -22,7 +22,9 @@ import io.vertx.core.json.JsonObject;
 import java.util.List;
 
 /**
- * A new partitions to be created
+ * An update to the number of partitions including assignment.
+ * Partitions can be increased only. If decrease, an exception from Kafka broker is received.
+ * If no assignment is specifies brokers will randomly assign the partitions.
  */
 @DataObject(generateConverter = true)
 public class NewPartitions {
@@ -83,7 +85,7 @@ public class NewPartitions {
     }
 
     /**
-     * Set the number of partitions for the topic
+     * Set the assignment for the new partitions
      * @param assignments assignments of the partitions to the brokers
      * @return current instance of the class to be fluent
      */

--- a/src/main/java/io/vertx/kafka/admin/impl/KafkaAdminClientImpl.java
+++ b/src/main/java/io/vertx/kafka/admin/impl/KafkaAdminClientImpl.java
@@ -196,15 +196,23 @@ public class KafkaAdminClientImpl implements KafkaAdminClient {
 
   @Override
   public void createPartitions(Map<String, NewPartitions> partitions, Handler<AsyncResult<Void>> completionHandler) {
+    createPartitions(partitions).onComplete(completionHandler);
+  }
+
+  @Override
+  public Future<Void> createPartitions(Map<String, NewPartitions> partitions) {
+    ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    Promise<Void> promise = ctx.promise();
     CreatePartitionsResult createPartitionsResult = this.adminClient.createPartitions(Helper.toPartitions(partitions));
     createPartitionsResult.all().whenComplete((v, ex) -> {
 
       if (ex == null) {
-        completionHandler.handle(Future.succeededFuture());
+        promise.handle(Future.succeededFuture());
       } else {
-        completionHandler.handle(Future.failedFuture(ex));
+        promise.handle(Future.failedFuture(ex));
       }
     });
+    return promise.future();
   }
 
 

--- a/src/main/java/io/vertx/kafka/admin/impl/KafkaAdminClientImpl.java
+++ b/src/main/java/io/vertx/kafka/admin/impl/KafkaAdminClientImpl.java
@@ -17,6 +17,7 @@
 package io.vertx.kafka.admin.impl;
 
 import io.vertx.kafka.admin.ListConsumerGroupOffsetsOptions;
+import io.vertx.kafka.admin.NewPartitions;
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.OffsetAndMetadata;
 import java.time.Duration;
@@ -47,6 +48,7 @@ import io.vertx.kafka.client.common.impl.Helper;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
 import org.apache.kafka.clients.admin.AlterConsumerGroupOffsetsResult;
+import org.apache.kafka.clients.admin.CreatePartitionsResult;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteConsumerGroupOffsetsResult;
 import org.apache.kafka.clients.admin.DeleteConsumerGroupsResult;
@@ -191,6 +193,20 @@ public class KafkaAdminClientImpl implements KafkaAdminClient {
     });
     return promise.future();
   }
+
+  @Override
+  public void createPartitions(Map<String, NewPartitions> partitions, Handler<AsyncResult<Void>> completionHandler) {
+    CreatePartitionsResult createPartitionsResult = this.adminClient.createPartitions(Helper.toPartitions(partitions));
+    createPartitionsResult.all().whenComplete((v, ex) -> {
+
+      if (ex == null) {
+        completionHandler.handle(Future.succeededFuture());
+      } else {
+        completionHandler.handle(Future.failedFuture(ex));
+      }
+    });
+  }
+
 
   @Override
   public void describeConfigs(List<ConfigResource> configResources, Handler<AsyncResult<Map<ConfigResource, Config>>> completionHandler) {

--- a/src/main/java/io/vertx/kafka/admin/impl/NewPartitions.java
+++ b/src/main/java/io/vertx/kafka/admin/impl/NewPartitions.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.kafka.admin;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+
+/**
+ * A new partitions to be created
+ */
+@DataObject(generateConverter = true)
+public class NewPartitions {
+
+    private int totalCount;
+
+    private List<List<Integer>> newAssignments;
+
+    /**
+     * Constructor
+     */
+    public NewPartitions() {
+
+    }
+
+
+    /**
+     * Constructor
+     *
+     * @param totalCount total count of partitions
+     * @param newAssignments assignment to the brokers
+     */
+    public NewPartitions(int totalCount, List<List<Integer>> newAssignments) {
+        this.totalCount = totalCount;
+        this.newAssignments = newAssignments;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param totalCount total count of partitions
+     */
+    public void NewPartitions(int totalCount) {
+        this.totalCount = totalCount;
+        this.newAssignments = null;
+    }
+
+
+    /**
+     * Constructor (from JSON representation)
+     *
+     * @param json  JSON representation
+     */
+    public NewPartitions(JsonObject json) {
+
+        NewPartitionsConverter.fromJson(json, this);
+    }
+
+
+    /**
+     * Set the number of partitions for the topic
+     * @param totalCount the number of partitions for the topic
+     * @return current instance of the class to be fluent
+     */
+    public NewPartitions setTotalCount(int totalCount) {
+        this.totalCount = totalCount;
+        return this;
+    }
+
+    /**
+     * Set the number of partitions for the topic
+     * @param assignments assignments of the partitions to the brokers
+     * @return current instance of the class to be fluent
+     */
+    public NewPartitions setNewAssignments(List<List<Integer>> assignments) {
+        this.newAssignments = assignments;
+        return this;
+    }
+
+    /**
+     * @return number of total partitions
+     */
+    public int getTotalCount() {
+        return this.totalCount;
+    }
+
+    /**
+     * @return assignment of partitions to the brokers
+     */
+    public List<List<Integer>> getNewAssignments() {
+        return this.newAssignments;
+    }
+
+    /**
+     * Convert object to JSON representation
+     *
+     * @return  JSON representation
+     */
+    public JsonObject toJson() {
+
+        JsonObject json = new JsonObject();
+        NewPartitionsConverter.toJson(this, json);
+        return json;
+    }
+
+    @Override
+    public String toString() {
+        return "NewPartitions{" +
+                "totalCount=" + this.totalCount +
+                ",newAssignments=" + this.newAssignments +
+                "}";
+    }
+
+}

--- a/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
+++ b/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
@@ -23,6 +23,7 @@ import io.vertx.kafka.admin.ConsumerGroupListing;
 import io.vertx.kafka.admin.ListConsumerGroupOffsetsOptions;
 import io.vertx.kafka.admin.ListOffsetsResultInfo;
 import io.vertx.kafka.admin.MemberAssignment;
+import io.vertx.kafka.admin.NewPartitions;
 import io.vertx.kafka.admin.NewTopic;
 import io.vertx.kafka.admin.OffsetSpec;
 import io.vertx.kafka.client.common.ConfigResource;
@@ -68,6 +69,13 @@ public class Helper {
     return offsets.entrySet().stream().collect(Collectors.toMap(
       e -> new org.apache.kafka.common.TopicPartition(e.getKey().getTopic(), e.getKey().getPartition()),
       e -> new org.apache.kafka.clients.consumer.OffsetAndMetadata(e.getValue().getOffset(), e.getValue().getMetadata()))
+    );
+  }
+
+  public static Map<String, org.apache.kafka.clients.admin.NewPartitions> toPartitions(Map<String, NewPartitions> newPartitions) {
+    return newPartitions.entrySet().stream().collect(Collectors.toMap(
+            e -> e.getKey(),
+            e -> org.apache.kafka.clients.admin.NewPartitions.increaseTo(e.getValue().getTotalCount(), e.getValue().getNewAssignments()))
     );
   }
 

--- a/src/test/java/io/vertx/kafka/client/common/tracing/TracingTest.java
+++ b/src/test/java/io/vertx/kafka/client/common/tracing/TracingTest.java
@@ -298,7 +298,7 @@ public class TracingTest extends KafkaClusterTestBase {
     }
 
     void init(String topic, int sent, int received) {
-      init(topic, sent, received, "localhost:9092", "localhost", "9092");
+      init(topic, sent, received, "localhost:9092,localhost:9093", "localhost", "9093");
     }
 
     void init(String topic, int sent, int received, String peerAddress, String host, String port) {

--- a/src/test/java/io/vertx/kafka/client/tests/AdminClientTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/AdminClientTest.java
@@ -136,11 +136,11 @@ public class AdminClientTest extends KafkaClusterTestBase {
 
         TopicPartitionInfo topicPartitionInfo = topicDescription.getPartitions().get(0);
         ctx.assertEquals(0, topicPartitionInfo.getPartition());
-        ctx.assertEquals(1, topicPartitionInfo.getLeader().getId());
+        ctx.assertTrue(topicPartitionInfo.getLeader().getId() == 1 || topicPartitionInfo.getLeader().getId() == 2);
         ctx.assertEquals(1, topicPartitionInfo.getReplicas().size());
-        ctx.assertEquals(1, topicPartitionInfo.getReplicas().get(0).getId());
+        ctx.assertTrue(topicPartitionInfo.getReplicas().get(0).getId() == 1 || topicPartitionInfo.getReplicas().get(0).getId() == 2);
         ctx.assertEquals(1, topicPartitionInfo.getIsr().size());
-        ctx.assertEquals(1, topicPartitionInfo.getIsr().get(0).getId());
+        ctx.assertTrue(topicPartitionInfo.getIsr().get(0).getId() == 1 || topicPartitionInfo.getIsr().get(0).getId() == 2);
 
         adminClient.close();
         async.complete();
@@ -466,7 +466,7 @@ public class AdminClientTest extends KafkaClusterTestBase {
         ctx.assertEquals(null, controller.rack());
         Collection<Node> nodes = cluster.getNodes();
         ctx.assertNotNull(nodes);
-        ctx.assertEquals(1, nodes.size());
+        ctx.assertEquals(2, nodes.size());
         ctx.assertEquals(1, nodes.iterator().next().getId());
         adminClient.close();
         async.complete();

--- a/src/test/java/io/vertx/kafka/client/tests/AdminClientTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/AdminClientTest.java
@@ -665,7 +665,7 @@ public class AdminClientTest extends KafkaClusterTestBase {
 
     KafkaAdminClient adminClient = KafkaAdminClient.create(this.vertx, config);
 
-    kafkaCluster.createTopic("topicToUpdatePartitions", 1, 1);
+    kafkaCluster.createTopic("testCreateNewPartitionInTopic", 1, 1);
 
     Async async = ctx.async();
 
@@ -674,11 +674,11 @@ public class AdminClientTest extends KafkaClusterTestBase {
 
       adminClient.listTopics(ctx.asyncAssertSuccess(topics -> {
 
-        ctx.assertTrue(topics.contains("topicToUpdatePartitions"));
+        ctx.assertTrue(topics.contains("testCreateNewPartitionInTopic"));
 
-        adminClient.createPartitions(Collections.singletonMap("topicToUpdatePartitions", new NewPartitions(3, null)), ctx.asyncAssertSuccess(v -> {
-          adminClient.describeTopics(Collections.singletonList("topicToUpdatePartitions"), ctx.asyncAssertSuccess(s -> {
-            ctx.assertTrue(s.get("topicToUpdatePartitions").getPartitions().size() == 3);
+        adminClient.createPartitions(Collections.singletonMap("testCreateNewPartitionInTopic", new NewPartitions(3, null)), ctx.asyncAssertSuccess(v -> {
+          adminClient.describeTopics(Collections.singletonList("testCreateNewPartitionInTopic"), ctx.asyncAssertSuccess(s -> {
+            ctx.assertTrue(s.get("testCreateNewPartitionInTopic").getPartitions().size() == 3);
             adminClient.close();
             async.complete();
           }));
@@ -692,7 +692,7 @@ public class AdminClientTest extends KafkaClusterTestBase {
 
     KafkaAdminClient adminClient = KafkaAdminClient.create(this.vertx, config);
 
-    kafkaCluster.createTopic("topicToUpdatePartitions", 3, 1);
+    kafkaCluster.createTopic("testDecreasePartitionInTopic", 3, 1);
 
     Async async = ctx.async();
 
@@ -701,9 +701,9 @@ public class AdminClientTest extends KafkaClusterTestBase {
 
       adminClient.listTopics(ctx.asyncAssertSuccess(topics -> {
 
-        ctx.assertTrue(topics.contains("topicToUpdatePartitions"));
+        ctx.assertTrue(topics.contains("testDecreasePartitionInTopic"));
 
-        adminClient.createPartitions(Collections.singletonMap("topicToUpdatePartitions", new NewPartitions(1, null)), ctx.asyncAssertFailure(v -> {
+        adminClient.createPartitions(Collections.singletonMap("testDecreasePartitionInTopic", new NewPartitions(1, null)), ctx.asyncAssertFailure(v -> {
           ctx.assertTrue(v.getMessage().equals("Topic currently has 3 partitions, which is higher than the requested 1."));
           adminClient.close();
           async.complete();

--- a/src/test/java/io/vertx/kafka/client/tests/AdminClientTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/AdminClientTest.java
@@ -42,6 +42,7 @@ import io.vertx.kafka.admin.ConsumerGroupDescription;
 import io.vertx.kafka.admin.ListOffsetsResultInfo;
 import io.vertx.kafka.admin.MemberAssignment;
 import io.vertx.kafka.admin.MemberDescription;
+import io.vertx.kafka.admin.NewPartitions;
 import io.vertx.kafka.admin.NewTopic;
 import io.vertx.kafka.admin.OffsetSpec;
 import io.vertx.kafka.admin.TopicDescription;
@@ -658,6 +659,59 @@ public class AdminClientTest extends KafkaClusterTestBase {
     Map<TopicPartition, OffsetSpec> topicPartitionBeginOffsets = Collections.singletonMap(topicPartition0, OffsetSpec.EARLIEST);
     adminClient.listOffsets(topicPartitionBeginOffsets, ctx.asyncAssertFailure());
   }
+
+  @Test
+  public void testCreateNewPartitionInTopic(TestContext ctx) {
+
+    KafkaAdminClient adminClient = KafkaAdminClient.create(this.vertx, config);
+
+    kafkaCluster.createTopic("topicToUpdatePartitions", 1, 1);
+
+    Async async = ctx.async();
+
+    // timer because, Kafka cluster takes time to create topics
+    vertx.setTimer(1000, t -> {
+
+      adminClient.listTopics(ctx.asyncAssertSuccess(topics -> {
+
+        ctx.assertTrue(topics.contains("topicToUpdatePartitions"));
+
+        adminClient.createPartitions(Collections.singletonMap("topicToUpdatePartitions", new NewPartitions(3, null)), ctx.asyncAssertSuccess(v -> {
+          adminClient.describeTopics(Collections.singletonList("topicToUpdatePartitions"), ctx.asyncAssertSuccess(s -> {
+            ctx.assertTrue(s.get("topicToUpdatePartitions").getPartitions().size() == 3);
+            adminClient.close();
+            async.complete();
+          }));
+        }));
+      }));
+    });
+  }
+
+  @Test
+  public void testDecreasePartitionInTopic(TestContext ctx) {
+
+    KafkaAdminClient adminClient = KafkaAdminClient.create(this.vertx, config);
+
+    kafkaCluster.createTopic("topicToUpdatePartitions", 3, 1);
+
+    Async async = ctx.async();
+
+    // timer because, Kafka cluster takes time to create topics
+    vertx.setTimer(1000, t -> {
+
+      adminClient.listTopics(ctx.asyncAssertSuccess(topics -> {
+
+        ctx.assertTrue(topics.contains("topicToUpdatePartitions"));
+
+        adminClient.createPartitions(Collections.singletonMap("topicToUpdatePartitions", new NewPartitions(1, null)), ctx.asyncAssertFailure(v -> {
+          ctx.assertTrue(v.getMessage().equals("Topic currently has 3 partitions, which is higher than the requested 1."));
+          adminClient.close();
+          async.complete();
+        }));
+      }));
+    });
+  }
+
 
   @Test
   public void testAsyncClose(TestContext ctx) {

--- a/src/test/java/io/vertx/kafka/client/tests/KafkaClusterTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/KafkaClusterTestBase.java
@@ -46,7 +46,7 @@ public class KafkaClusterTestBase extends KafkaTestBase {
 
   @BeforeClass
   public static void setUp() throws IOException {
-    kafkaCluster = kafkaCluster().deleteDataPriorToStartup(true).addBrokers(1).startup();
+    kafkaCluster = kafkaCluster().deleteDataPriorToStartup(true).addBrokers(2).startup();
   }
 
 


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

Motivation:
Topic can be created with _n_ partitions. Kafka supports increase of this number and so should this client.