### PR TITLE
Add generated dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ test-tmp
 *.swp
 .vertx
 .vscode
+/src/main/generated/


### PR DESCRIPTION
Signed-off-by: Stanislav Knot <sknot@redhat.com>

Motivation:
`mvn clean install -DskipTests` generated bunch of files which should not be added to the repository.
