### PR TITLE
Support ACL operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
 
   <properties>
     <stack.version>4.2.1-SNAPSHOT</stack.version>
-    <kafka.version>2.6.0</kafka.version>
-    <debezium.version>0.8.3.Final</debezium.version>
+    <kafka.version>2.7.0</kafka.version>
+    <debezium.version>1.6.0.Final</debezium.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
 
   <properties>
     <stack.version>4.2.1-SNAPSHOT</stack.version>
-    <kafka.version>2.7.0</kafka.version>
-    <debezium.version>1.6.0.Final</debezium.version>
+    <kafka.version>2.8.1</kafka.version>
+    <debezium.version>1.7.0.Final</debezium.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
 

--- a/src/main/java/io/vertx/kafka/admin/AccessControlEntry.java
+++ b/src/main/java/io/vertx/kafka/admin/AccessControlEntry.java
@@ -52,5 +52,4 @@ public class AccessControlEntry {
     public AclPermissionType permissionType() {
         return data.permissionType();
     }
-
 }

--- a/src/main/java/io/vertx/kafka/admin/AccessControlEntry.java
+++ b/src/main/java/io/vertx/kafka/admin/AccessControlEntry.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.vertx.kafka.admin;
 
 import java.util.Objects;

--- a/src/main/java/io/vertx/kafka/admin/AccessControlEntry.java
+++ b/src/main/java/io/vertx/kafka/admin/AccessControlEntry.java
@@ -1,0 +1,56 @@
+package io.vertx.kafka.admin;
+
+import java.util.Objects;
+
+public class AccessControlEntry {
+    final AccessControlEntryData data;
+
+    /**
+     * Create an instance of an access control entry with the provided parameters.
+     *
+     * @param principal non-null principal
+     * @param host non-null host
+     * @param operation non-null operation, ANY is not an allowed operation
+     * @param permissionType non-null permission type, ANY is not an allowed type
+     */
+    public AccessControlEntry(String principal, String host, AclOperation operation, AclPermissionType permissionType) {
+        Objects.requireNonNull(principal);
+        Objects.requireNonNull(host);
+        Objects.requireNonNull(operation);
+        if (operation == AclOperation.ANY)
+            throw new IllegalArgumentException("operation must not be ANY");
+        Objects.requireNonNull(permissionType);
+        if (permissionType == AclPermissionType.ANY)
+            throw new IllegalArgumentException("permissionType must not be ANY");
+        this.data = new AccessControlEntryData(principal, host, operation, permissionType);
+    }
+
+    /**
+     * Return the principal for this entry.
+     */
+    public String principal() {
+        return data.principal();
+    }
+
+    /**
+     * Return the host or `*` for all hosts.
+     */
+    public String host() {
+        return data.host();
+    }
+
+    /**
+     * Return the AclOperation. This method will never return AclOperation.ANY.
+     */
+    public AclOperation operation() {
+        return data.operation();
+    }
+
+    /**
+     * Return the AclPermissionType. This method will never return AclPermissionType.ANY.
+     */
+    public AclPermissionType permissionType() {
+        return data.permissionType();
+    }
+
+}

--- a/src/main/java/io/vertx/kafka/admin/AccessControlEntryData.java
+++ b/src/main/java/io/vertx/kafka/admin/AccessControlEntryData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.vertx.kafka.admin;
 
 class AccessControlEntryData {

--- a/src/main/java/io/vertx/kafka/admin/AccessControlEntryData.java
+++ b/src/main/java/io/vertx/kafka/admin/AccessControlEntryData.java
@@ -1,0 +1,59 @@
+package io.vertx.kafka.admin;
+
+class AccessControlEntryData {
+    private final String principal;
+    private final String host;
+    private final AclOperation operation;
+    private final AclPermissionType permissionType;
+
+    AccessControlEntryData(String principal, String host, AclOperation operation, AclPermissionType permissionType) {
+        this.principal = principal;
+        this.host = host;
+        this.operation = operation;
+        this.permissionType = permissionType;
+    }
+
+    String principal() {
+        return principal;
+    }
+
+    String host() {
+        return host;
+    }
+
+    AclOperation operation() {
+        return operation;
+    }
+
+    AclPermissionType permissionType() {
+        return permissionType;
+    }
+
+    /**
+     * Returns a string describing an ANY or UNKNOWN field, or null if there is
+     * no such field.
+     */
+    public String findIndefiniteField() {
+        if (principal() == null)
+            return "Principal is NULL";
+        if (host() == null)
+            return "Host is NULL";
+        if (operation() == AclOperation.ANY)
+            return "Operation is ANY";
+        if (operation() == AclOperation.UNKNOWN)
+            return "Operation is UNKNOWN";
+        if (permissionType() == AclPermissionType.ANY)
+            return "Permission type is ANY";
+        if (permissionType() == AclPermissionType.UNKNOWN)
+            return "Permission type is UNKNOWN";
+        return null;
+    }
+
+    /**
+     * Return true if there are any UNKNOWN components.
+     */
+    boolean isUnknown() {
+        return operation.isUnknown() || permissionType.isUnknown();
+    }
+}
+

--- a/src/main/java/io/vertx/kafka/admin/AccessControlEntryData.java
+++ b/src/main/java/io/vertx/kafka/admin/AccessControlEntryData.java
@@ -56,4 +56,3 @@ class AccessControlEntryData {
         return operation.isUnknown() || permissionType.isUnknown();
     }
 }
-

--- a/src/main/java/io/vertx/kafka/admin/AccessControlEntryFilter.java
+++ b/src/main/java/io/vertx/kafka/admin/AccessControlEntryFilter.java
@@ -1,0 +1,93 @@
+package io.vertx.kafka.admin;
+
+import java.util.Objects;
+
+public class AccessControlEntryFilter {
+    private final AccessControlEntryData data;
+
+    /**
+     * Matches any access control entry.
+     */
+    public static final AccessControlEntryFilter ANY =
+            new AccessControlEntryFilter(null, null, AclOperation.ANY, AclPermissionType.ANY);
+
+    /**
+     * Create an instance of an access control entry filter with the provided parameters.
+     *
+     * @param principal the principal or null
+     * @param host the host or null
+     * @param operation non-null operation
+     * @param permissionType non-null permission type
+     */
+    public AccessControlEntryFilter(String principal, String host, AclOperation operation, AclPermissionType permissionType) {
+        Objects.requireNonNull(operation);
+        Objects.requireNonNull(permissionType);
+        this.data = new AccessControlEntryData(principal, host, operation, permissionType);
+    }
+
+    /**
+     * This is a non-public constructor used in AccessControlEntry#toFilter
+     *
+     * @param data     The access control data.
+     */
+    AccessControlEntryFilter(AccessControlEntryData data) {
+        this.data = data;
+    }
+
+    /**
+     * Return the principal or null.
+     */
+    public String principal() {
+        return data.principal();
+    }
+
+    /**
+     * Return the host or null. The value `*` means any host.
+     */
+    public String host() {
+        return data.host();
+    }
+
+    /**
+     * Return the AclOperation.
+     */
+    public AclOperation operation() {
+        return data.operation();
+    }
+
+    /**
+     * Return the AclPermissionType.
+     */
+    public AclPermissionType permissionType() {
+        return data.permissionType();
+    }
+
+    @Override
+    public String toString() {
+        return data.toString();
+    }
+
+    /**
+     * Return true if there are any UNKNOWN components.
+     */
+    public boolean isUnknown() {
+        return data.isUnknown();
+    }
+
+    /**
+     * Returns true if this filter could only match one ACE -- in other words, if
+     * there are no ANY or UNKNOWN fields.
+     */
+    public boolean matchesAtMostOne() {
+        return findIndefiniteField() == null;
+    }
+
+    /**
+     * Returns a string describing an ANY or UNKNOWN field, or null if there is
+     * no such field.
+     */
+    public String findIndefiniteField() {
+        return data.findIndefiniteField();
+    }
+
+}

--- a/src/main/java/io/vertx/kafka/admin/AccessControlEntryFilter.java
+++ b/src/main/java/io/vertx/kafka/admin/AccessControlEntryFilter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.vertx.kafka.admin;
 
 import java.util.Objects;

--- a/src/main/java/io/vertx/kafka/admin/AclBinding.java
+++ b/src/main/java/io/vertx/kafka/admin/AclBinding.java
@@ -1,5 +1,20 @@
-package io.vertx.kafka.admin;
+/*
+ * Copyright 2021 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package io.vertx.kafka.admin;
 
 import java.util.Objects;
 

--- a/src/main/java/io/vertx/kafka/admin/AclBinding.java
+++ b/src/main/java/io/vertx/kafka/admin/AclBinding.java
@@ -1,0 +1,44 @@
+package io.vertx.kafka.admin;
+
+
+import org.apache.kafka.common.acl.AccessControlEntry;
+import org.apache.kafka.common.resource.ResourcePattern;
+
+import java.util.Objects;
+
+public class AclBinding {
+    private final ResourcePattern pattern;
+    private final AccessControlEntry entry;
+
+    /**
+     * Create an instance of this class with the provided parameters.
+     *
+     * @param pattern non-null resource pattern.
+     * @param entry non-null entry
+     */
+    public AclBinding(ResourcePattern pattern, AccessControlEntry entry) {
+        this.pattern = Objects.requireNonNull(pattern, "pattern");
+        this.entry = Objects.requireNonNull(entry, "entry");
+    }
+
+    /**
+     * @return true if this binding has any UNKNOWN components.
+     */
+    public boolean isUnknown() {
+        return pattern.isUnknown() || entry.isUnknown();
+    }
+
+    /**
+     * @return the resource pattern for this binding.
+     */
+    public ResourcePattern pattern() {
+        return pattern;
+    }
+
+    /**
+     * @return the access control entry for this binding.
+     */
+    public final AccessControlEntry entry() {
+        return entry;
+    }
+}

--- a/src/main/java/io/vertx/kafka/admin/AclBinding.java
+++ b/src/main/java/io/vertx/kafka/admin/AclBinding.java
@@ -1,9 +1,6 @@
 package io.vertx.kafka.admin;
 
 
-import org.apache.kafka.common.acl.AccessControlEntry;
-import org.apache.kafka.common.resource.ResourcePattern;
-
 import java.util.Objects;
 
 public class AclBinding {
@@ -19,13 +16,6 @@ public class AclBinding {
     public AclBinding(ResourcePattern pattern, AccessControlEntry entry) {
         this.pattern = Objects.requireNonNull(pattern, "pattern");
         this.entry = Objects.requireNonNull(entry, "entry");
-    }
-
-    /**
-     * @return true if this binding has any UNKNOWN components.
-     */
-    public boolean isUnknown() {
-        return pattern.isUnknown() || entry.isUnknown();
     }
 
     /**

--- a/src/main/java/io/vertx/kafka/admin/AclBindingFilter.java
+++ b/src/main/java/io/vertx/kafka/admin/AclBindingFilter.java
@@ -1,0 +1,38 @@
+package io.vertx.kafka.admin;
+
+import java.util.Objects;
+
+public class AclBindingFilter {
+    private final ResourcePatternFilter patternFilter;
+    private final AccessControlEntryFilter entryFilter;
+
+    /**
+     * A filter which matches any ACL binding.
+     */
+    public static final AclBindingFilter ANY = new AclBindingFilter(ResourcePatternFilter.ANY, AccessControlEntryFilter.ANY);
+
+    /**
+     * Create an instance of this filter with the provided parameters.
+     *
+     * @param patternFilter non-null pattern filter
+     * @param entryFilter non-null access control entry filter
+     */
+    public AclBindingFilter(ResourcePatternFilter patternFilter, AccessControlEntryFilter entryFilter) {
+        this.patternFilter = Objects.requireNonNull(patternFilter, "patternFilter");
+        this.entryFilter = Objects.requireNonNull(entryFilter, "entryFilter");
+    }
+
+    /**
+     * @return the resource pattern filter.
+     */
+    public ResourcePatternFilter patternFilter() {
+        return patternFilter;
+    }
+
+    /**
+     * @return the access control entry filter.
+     */
+    public final AccessControlEntryFilter entryFilter() {
+        return entryFilter;
+    }
+}

--- a/src/main/java/io/vertx/kafka/admin/AclBindingFilter.java
+++ b/src/main/java/io/vertx/kafka/admin/AclBindingFilter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.vertx.kafka.admin;
 
 import java.util.Objects;

--- a/src/main/java/io/vertx/kafka/admin/AclOperation.java
+++ b/src/main/java/io/vertx/kafka/admin/AclOperation.java
@@ -1,0 +1,89 @@
+package io.vertx.kafka.admin;
+
+public enum AclOperation {
+    /**
+     * Represents any AclOperation which this client cannot understand, perhaps because this
+     * client is too old.
+     */
+    UNKNOWN((byte) 0),
+
+    /**
+     * In a filter, matches any AclOperation.
+     */
+    ANY((byte) 1),
+
+    /**
+     * ALL operation.
+     */
+    ALL((byte) 2),
+
+    /**
+     * READ operation.
+     */
+    READ((byte) 3),
+
+    /**
+     * WRITE operation.
+     */
+    WRITE((byte) 4),
+
+    /**
+     * CREATE operation.
+     */
+    CREATE((byte) 5),
+
+    /**
+     * DELETE operation.
+     */
+    DELETE((byte) 6),
+
+    /**
+     * ALTER operation.
+     */
+    ALTER((byte) 7),
+
+    /**
+     * DESCRIBE operation.
+     */
+    DESCRIBE((byte) 8),
+
+    /**
+     * CLUSTER_ACTION operation.
+     */
+    CLUSTER_ACTION((byte) 9),
+
+    /**
+     * DESCRIBE_CONFIGS operation.
+     */
+    DESCRIBE_CONFIGS((byte) 10),
+
+    /**
+     * ALTER_CONFIGS operation.
+     */
+    ALTER_CONFIGS((byte) 11),
+
+    /**
+     * IDEMPOTENT_WRITE operation.
+     */
+    IDEMPOTENT_WRITE((byte) 12);
+
+    private final byte code;
+
+    AclOperation(byte code) {
+        this.code = code;
+    }
+
+    /**
+     * Return the code of this operation.
+     */
+    public byte code() {
+        return code;
+    }
+
+    /**
+     * Return true if this operation is UNKNOWN.
+     */
+    public boolean isUnknown() {
+        return this == UNKNOWN;
+    }
+}

--- a/src/main/java/io/vertx/kafka/admin/AclOperation.java
+++ b/src/main/java/io/vertx/kafka/admin/AclOperation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.vertx.kafka.admin;
 
 public enum AclOperation {

--- a/src/main/java/io/vertx/kafka/admin/AclPermissionType.java
+++ b/src/main/java/io/vertx/kafka/admin/AclPermissionType.java
@@ -1,0 +1,44 @@
+package io.vertx.kafka.admin;
+
+public enum AclPermissionType {
+    /**
+     * Represents any AclPermissionType which this client cannot understand,
+     * perhaps because this client is too old.
+     */
+    UNKNOWN((byte) 0),
+
+    /**
+     * In a filter, matches any AclPermissionType.
+     */
+    ANY((byte) 1),
+
+    /**
+     * Disallows access.
+     */
+    DENY((byte) 2),
+
+    /**
+     * Grants access.
+     */
+    ALLOW((byte) 3);
+
+    private final byte code;
+
+    AclPermissionType(byte code) {
+        this.code = code;
+    }
+
+    /**
+     * Return the code of this permission type.
+     */
+    public byte code() {
+        return code;
+    }
+
+    /**
+     * Return true if this permission type is UNKNOWN.
+     */
+    public boolean isUnknown() {
+        return this == UNKNOWN;
+    }
+}

--- a/src/main/java/io/vertx/kafka/admin/AclPermissionType.java
+++ b/src/main/java/io/vertx/kafka/admin/AclPermissionType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.vertx.kafka.admin;
 
 public enum AclPermissionType {

--- a/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
+++ b/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
@@ -28,8 +28,8 @@ import io.vertx.core.Vertx;
 import io.vertx.kafka.admin.impl.KafkaAdminClientImpl;
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.OffsetAndMetadata;
-import org.apache.kafka.common.acl.AclBinding;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -303,12 +303,11 @@ public interface KafkaAdminClient {
   @GenIgnore
   Future<Map<TopicPartition, ListOffsetsResultInfo>> listOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets);
 
-
   /**
    * Describe the ACL rules.
    *
    * @param aclBindingFilter The filter to use.
-   * @param completionHandler handler called on operation completed with the ACl description result.
+   * @param completionHandler handler called on operation completed with the ACL description result.
    */
   @GenIgnore
   void describeAcls(AclBindingFilter aclBindingFilter, Handler<AsyncResult<List<AclBinding>>> completionHandler);
@@ -318,6 +317,21 @@ public interface KafkaAdminClient {
    */
   @GenIgnore
   Future<List<AclBinding>> describeAcls(AclBindingFilter aclBindingFilter);
+
+  /**
+   * Create the ACL rules.
+   *
+   * @param aclBindings The ACL to create.
+   * @param completionHandler handler called on operation completed with the ACL creation result.
+   */
+  @GenIgnore
+  void createAcls(Collection<AclBinding> aclBindings, Handler<AsyncResult<List<AclBinding>>> completionHandler);
+
+  /**
+   * Like {@link #createAcls(Collection)} (Collection<AclBinding>, Handler)} but returns a {@code Future} of the asynchronous result
+   */
+  @GenIgnore
+  Future<List<AclBinding>> createAcls(Collection<AclBinding> aclBindings);
 
   /**
    * Close the admin client

--- a/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
+++ b/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
@@ -28,6 +28,8 @@ import io.vertx.core.Vertx;
 import io.vertx.kafka.admin.impl.KafkaAdminClientImpl;
 import io.vertx.kafka.client.common.TopicPartition;
 import io.vertx.kafka.client.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.acl.AclBinding;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -300,6 +302,22 @@ public interface KafkaAdminClient {
    */
   @GenIgnore
   Future<Map<TopicPartition, ListOffsetsResultInfo>> listOffsets(Map<TopicPartition, OffsetSpec> topicPartitionOffsets);
+
+
+  /**
+   * Describe the ACL rules.
+   *
+   * @param aclBindingFilter The filter to use.
+   * @param completionHandler handler called on operation completed with the ACl description result.
+   */
+  @GenIgnore
+  void describeAcls(AclBindingFilter aclBindingFilter, Handler<AsyncResult<List<AclBinding>>> completionHandler);
+
+  /**
+   * Like {@link #describeAcls(AclBindingFilter, Handler)} but returns a {@code Future} of the asynchronous result
+   */
+  @GenIgnore
+  Future<List<AclBinding>> describeAcls(AclBindingFilter aclBindingFilter);
 
   /**
    * Close the admin client

--- a/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
+++ b/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
@@ -309,13 +309,13 @@ public interface KafkaAdminClient {
    * @param aclBindingFilter The filter to use.
    * @param completionHandler handler called on operation completed with the ACL description result.
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   void describeAcls(AclBindingFilter aclBindingFilter, Handler<AsyncResult<List<AclBinding>>> completionHandler);
 
   /**
    * Like {@link #describeAcls(AclBindingFilter, Handler)} but returns a {@code Future} of the asynchronous result
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Future<List<AclBinding>> describeAcls(AclBindingFilter aclBindingFilter);
 
   /**
@@ -324,13 +324,13 @@ public interface KafkaAdminClient {
    * @param aclBindings The ACL to create.
    * @param completionHandler handler called on operation completed with the ACL creation result.
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   void createAcls(Collection<AclBinding> aclBindings, Handler<AsyncResult<List<AclBinding>>> completionHandler);
 
   /**
    * Like {@link #createAcls(Collection)} (Collection<AclBinding>, Handler)} but returns a {@code Future} of the asynchronous result
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Future<List<AclBinding>> createAcls(Collection<AclBinding> aclBindings);
 
   /**
@@ -339,13 +339,13 @@ public interface KafkaAdminClient {
    * @param aclBindings The filter to delete matching ACLs.
    * @param completionHandler handler called on operation completed with the ACL deletion result.
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   void deleteAcls(Collection<AclBindingFilter> aclBindings, Handler<AsyncResult<List<AclBinding>>> completionHandler);
 
   /**
    * Like {@link #deleteAcls(Collection)} (Collection<AclBinding>, Handler)} but returns a {@code Future} of the asynchronous result
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Future<List<AclBinding>> deleteAcls(Collection<AclBindingFilter> aclBindings);
 
   /**

--- a/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
+++ b/src/main/java/io/vertx/kafka/admin/KafkaAdminClient.java
@@ -334,6 +334,21 @@ public interface KafkaAdminClient {
   Future<List<AclBinding>> createAcls(Collection<AclBinding> aclBindings);
 
   /**
+   * Delete the ACL rules.
+   *
+   * @param aclBindings The filter to delete matching ACLs.
+   * @param completionHandler handler called on operation completed with the ACL deletion result.
+   */
+  @GenIgnore
+  void deleteAcls(Collection<AclBindingFilter> aclBindings, Handler<AsyncResult<List<AclBinding>>> completionHandler);
+
+  /**
+   * Like {@link #deleteAcls(Collection)} (Collection<AclBinding>, Handler)} but returns a {@code Future} of the asynchronous result
+   */
+  @GenIgnore
+  Future<List<AclBinding>> deleteAcls(Collection<AclBindingFilter> aclBindings);
+
+  /**
    * Close the admin client
    *
    * @param handler a {@code Handler} completed with the operation result

--- a/src/main/java/io/vertx/kafka/admin/ListConsumerGroupOffsetsOptions.java
+++ b/src/main/java/io/vertx/kafka/admin/ListConsumerGroupOffsetsOptions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.vertx.kafka.admin;
 
 import io.vertx.codegen.annotations.DataObject;

--- a/src/main/java/io/vertx/kafka/admin/PatternType.java
+++ b/src/main/java/io/vertx/kafka/admin/PatternType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.vertx.kafka.admin;
 
 import java.util.Arrays;

--- a/src/main/java/io/vertx/kafka/admin/PatternType.java
+++ b/src/main/java/io/vertx/kafka/admin/PatternType.java
@@ -1,0 +1,87 @@
+package io.vertx.kafka.admin;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum PatternType {
+    /**
+     * Represents any PatternType which this client cannot understand, perhaps because this client is too old.
+     */
+    UNKNOWN((byte) 0),
+
+    /**
+     * In a filter, matches any resource pattern type.
+     */
+    ANY((byte) 1),
+
+    /**
+     * In a filter, will perform pattern matching.
+     *
+     * e.g. Given a filter of {@code ResourcePatternFilter(TOPIC, "payments.received", MATCH)`}, the filter match
+     * any ResourcePattern that matches topic 'payments.received'. This might include:
+     * <ul>
+     *     <li>A Literal pattern with the same type and name, e.g. {@code ResourcePattern(TOPIC, "payments.received", LITERAL)}</li>
+     *     <li>A Wildcard pattern with the same type, e.g. {@code ResourcePattern(TOPIC, "*", LITERAL)}</li>
+     *     <li>A Prefixed pattern with the same type and where the name is a matching prefix, e.g. {@code ResourcePattern(TOPIC, "payments.", PREFIXED)}</li>
+     * </ul>
+     */
+    MATCH((byte) 2),
+
+    /**
+     * A literal resource name.
+     *
+     * A literal name defines the full name of a resource, e.g. topic with name 'foo', or group with name 'bob'.
+     *
+     * The special wildcard character {@code *} can be used to represent a resource with any name.
+     */
+    LITERAL((byte) 3),
+
+    /**
+     * A prefixed resource name.
+     *
+     * A prefixed name defines a prefix for a resource, e.g. topics with names that start with 'foo'.
+     */
+    PREFIXED((byte) 4);
+
+    private final static Map<Byte, PatternType> CODE_TO_VALUE =
+            Collections.unmodifiableMap(
+                    Arrays.stream(PatternType.values())
+                            .collect(Collectors.toMap(PatternType::code, Function.identity()))
+            );
+
+    private final static Map<String, PatternType> NAME_TO_VALUE =
+            Collections.unmodifiableMap(
+                    Arrays.stream(PatternType.values())
+                            .collect(Collectors.toMap(PatternType::name, Function.identity()))
+            );
+
+    private final byte code;
+
+    PatternType(byte code) {
+        this.code = code;
+    }
+
+    /**
+     * @return the code of this resource.
+     */
+    public byte code() {
+        return code;
+    }
+
+    /**
+     * @return whether this resource pattern type is UNKNOWN.
+     */
+    public boolean isUnknown() {
+        return this == UNKNOWN;
+    }
+
+    /**
+     * @return whether this resource pattern type is a concrete type, rather than UNKNOWN or one of the filter types.
+     */
+    public boolean isSpecific() {
+        return this != UNKNOWN && this != ANY && this != MATCH;
+    }
+}

--- a/src/main/java/io/vertx/kafka/admin/ResourcePattern.java
+++ b/src/main/java/io/vertx/kafka/admin/ResourcePattern.java
@@ -1,0 +1,93 @@
+package io.vertx.kafka.admin;
+
+import java.util.Objects;
+
+public class ResourcePattern {
+    /**
+     * A special literal resource name that corresponds to 'all resources of a certain type'.
+     */
+    public static final String WILDCARD_RESOURCE = "*";
+
+    private final ResourceType resourceType;
+    private final String name;
+    private final PatternType patternType;
+
+    /**
+     * Create a pattern using the supplied parameters.
+     *
+     * @param resourceType non-null, specific, resource type
+     * @param name non-null resource name, which can be the {@link #WILDCARD_RESOURCE}.
+     * @param patternType non-null, specific, resource pattern type, which controls how the pattern will match resource names.
+     */
+    public ResourcePattern(ResourceType resourceType, String name, PatternType patternType) {
+        this.resourceType = Objects.requireNonNull(resourceType, "resourceType");
+        this.name = Objects.requireNonNull(name, "name");
+        this.patternType = Objects.requireNonNull(patternType, "patternType");
+
+        if (resourceType == ResourceType.ANY) {
+            throw new IllegalArgumentException("resourceType must not be ANY");
+        }
+
+        if (patternType == PatternType.MATCH || patternType == PatternType.ANY) {
+            throw new IllegalArgumentException("patternType must not be " + patternType);
+        }
+    }
+
+    /**
+     * @return the specific resource type this pattern matches
+     */
+    public ResourceType resourceType() {
+        return resourceType;
+    }
+
+    /**
+     * @return the resource name.
+     */
+    public String name() {
+        return name;
+    }
+
+    /**
+     * @return the resource pattern type.
+     */
+    public PatternType patternType() {
+        return patternType;
+    }
+
+    /**
+     * @return a filter which matches only this pattern.
+     */
+    public ResourcePatternFilter toFilter() {
+        return new ResourcePatternFilter(resourceType, name, patternType);
+    }
+
+    @Override
+    public String toString() {
+        return "ResourcePattern(resourceType=" + resourceType + ", name=" + ((name == null) ? "<any>" : name) + ", patternType=" + patternType + ")";
+    }
+
+    /**
+     * @return {@code true} if this Resource has any UNKNOWN components.
+     */
+    public boolean isUnknown() {
+        return resourceType.isUnknown() || patternType.isUnknown();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        final ResourcePattern resource = (ResourcePattern) o;
+        return resourceType == resource.resourceType &&
+                Objects.equals(name, resource.name) &&
+                patternType == resource.patternType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resourceType, name, patternType);
+    }
+}

--- a/src/main/java/io/vertx/kafka/admin/ResourcePattern.java
+++ b/src/main/java/io/vertx/kafka/admin/ResourcePattern.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.vertx.kafka.admin;
 
 import java.util.Objects;

--- a/src/main/java/io/vertx/kafka/admin/ResourcePatternFilter.java
+++ b/src/main/java/io/vertx/kafka/admin/ResourcePatternFilter.java
@@ -1,5 +1,20 @@
-package io.vertx.kafka.admin;
+/*
+ * Copyright 2021 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package io.vertx.kafka.admin;
 
 import java.util.Objects;
 

--- a/src/main/java/io/vertx/kafka/admin/ResourcePatternFilter.java
+++ b/src/main/java/io/vertx/kafka/admin/ResourcePatternFilter.java
@@ -1,0 +1,58 @@
+package io.vertx.kafka.admin;
+
+
+import java.util.Objects;
+
+public class ResourcePatternFilter {
+    /**
+     * Matches any resource pattern.
+     */
+    public static final ResourcePatternFilter ANY = new ResourcePatternFilter(ResourceType.ANY, null, PatternType.ANY);
+
+    private final ResourceType resourceType;
+    private final String name;
+    private final PatternType patternType;
+
+    /**
+     * Create a filter using the supplied parameters.
+     *
+     * @param resourceType non-null resource type.
+     *                     If {@link ResourceType#ANY}, the filter will ignore the resource type of the pattern.
+     *                     If any other resource type, the filter will match only patterns with the same type.
+     * @param name         resource name or {@code null}.
+     *                     If {@code null}, the filter will ignore the name of resources.
+     *                     If {@link ResourcePattern#WILDCARD_RESOURCE}, will match only wildcard patterns.
+     * @param patternType  non-null resource pattern type.
+     *                     If {@link PatternType#ANY}, the filter will match patterns regardless of pattern type.
+     *                     If {@link PatternType#MATCH}, the filter will match patterns that would match the supplied
+     *                     {@code name}, including a matching prefixed and wildcards patterns.
+     *                     If any other resource pattern type, the filter will match only patterns with the same type.
+     */
+    public ResourcePatternFilter(ResourceType resourceType, String name, PatternType patternType) {
+        this.resourceType = Objects.requireNonNull(resourceType, "resourceType");
+        this.name = name;
+        this.patternType = Objects.requireNonNull(patternType, "patternType");
+    }
+
+
+    /**
+     * @return the specific resource type this pattern matches
+     */
+    public ResourceType resourceType() {
+        return resourceType;
+    }
+
+    /**
+     * @return the resource name.
+     */
+    public String name() {
+        return name;
+    }
+
+    /**
+     * @return the resource pattern type.
+     */
+    public PatternType patternType() {
+        return patternType;
+    }
+}

--- a/src/main/java/io/vertx/kafka/admin/ResourceType.java
+++ b/src/main/java/io/vertx/kafka/admin/ResourceType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.vertx.kafka.admin;
 
 import java.util.HashMap;

--- a/src/main/java/io/vertx/kafka/admin/ResourceType.java
+++ b/src/main/java/io/vertx/kafka/admin/ResourceType.java
@@ -1,0 +1,96 @@
+package io.vertx.kafka.admin;
+
+import java.util.HashMap;
+import java.util.Locale;
+
+public enum ResourceType {
+    /**
+     * Represents any ResourceType which this client cannot understand,
+     * perhaps because this client is too old.
+     */
+    UNKNOWN((byte) 0),
+
+    /**
+     * In a filter, matches any ResourceType.
+     */
+    ANY((byte) 1),
+
+    /**
+     * A Kafka topic.
+     */
+    TOPIC((byte) 2),
+
+    /**
+     * A consumer group.
+     */
+    GROUP((byte) 3),
+
+    /**
+     * The cluster as a whole.
+     */
+    CLUSTER((byte) 4),
+
+    /**
+     * A transactional ID.
+     */
+    TRANSACTIONAL_ID((byte) 5),
+
+    /**
+     * A token ID.
+     */
+    DELEGATION_TOKEN((byte) 6);
+
+    private final static HashMap<Byte, ResourceType> CODE_TO_VALUE = new HashMap<>();
+
+    static {
+        for (ResourceType resourceType : ResourceType.values()) {
+            CODE_TO_VALUE.put(resourceType.code, resourceType);
+        }
+    }
+
+    /**
+     * Parse the given string as an ACL resource type.
+     *
+     * @param str    The string to parse.
+     *
+     * @return       The ResourceType, or UNKNOWN if the string could not be matched.
+     */
+    public static ResourceType fromString(String str) throws IllegalArgumentException {
+        try {
+            return ResourceType.valueOf(str.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return UNKNOWN;
+        }
+    }
+
+    /**
+     * Return the ResourceType with the provided code or `ResourceType.UNKNOWN` if one cannot be found.
+     */
+    public static ResourceType fromCode(byte code) {
+        ResourceType resourceType = CODE_TO_VALUE.get(code);
+        if (resourceType == null) {
+            return UNKNOWN;
+        }
+        return resourceType;
+    }
+
+    private final byte code;
+
+    ResourceType(byte code) {
+        this.code = code;
+    }
+
+    /**
+     * Return the code of this resource.
+     */
+    public byte code() {
+        return code;
+    }
+
+    /**
+     * Return whether this resource type is UNKNOWN.
+     */
+    public boolean isUnknown() {
+        return this == UNKNOWN;
+    }
+}

--- a/src/main/java/io/vertx/kafka/admin/impl/KafkaAdminClientImpl.java
+++ b/src/main/java/io/vertx/kafka/admin/impl/KafkaAdminClientImpl.java
@@ -16,6 +16,7 @@
 
 package io.vertx.kafka.admin.impl;
 
+import io.vertx.kafka.admin.AclBindingFilter;
 import io.vertx.kafka.admin.ListConsumerGroupOffsetsOptions;
 import io.vertx.kafka.admin.NewPartitions;
 import io.vertx.kafka.client.common.TopicPartition;
@@ -53,6 +54,7 @@ import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteConsumerGroupOffsetsResult;
 import org.apache.kafka.clients.admin.DeleteConsumerGroupsResult;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
+import org.apache.kafka.clients.admin.DescribeAclsResult;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.admin.DescribeConsumerGroupsResult;
@@ -68,6 +70,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.kafka.admin.KafkaAdminClient;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.acl.AclBinding;
 
 public class KafkaAdminClientImpl implements KafkaAdminClient {
 
@@ -482,6 +485,27 @@ public class KafkaAdminClientImpl implements KafkaAdminClient {
           listOffsets.put(Helper.from(oOffset.getKey()), Helper.from(oOffset.getValue()));
         }
         promise.complete(listOffsets);
+      } else {
+        promise.fail(ex);
+      }
+    });
+    return promise.future();
+  }
+
+  public void describeAcls(AclBindingFilter aclBindingFilter, Handler<AsyncResult<List<AclBinding>>> completionHandler) {
+    describeAcls(aclBindingFilter).onComplete(completionHandler);
+  }
+
+  public Future<List<AclBinding>> describeAcls(AclBindingFilter aclBindingFilter) {
+    ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    Promise<List<AclBinding>> promise = ctx.promise();
+
+    DescribeAclsResult describeAclsResult = this.adminClient.describeAcls(Helper.to(aclBindingFilter));
+    describeAclsResult.values().whenComplete((o, ex) -> {
+      if (ex == null) {
+        List<AclBinding> describeAcl = new ArrayList();
+
+        promise.complete(describeAcl);
       } else {
         promise.fail(ex);
       }

--- a/src/main/java/io/vertx/kafka/admin/impl/KafkaAdminClientImpl.java
+++ b/src/main/java/io/vertx/kafka/admin/impl/KafkaAdminClientImpl.java
@@ -53,6 +53,7 @@ import org.apache.kafka.clients.admin.AlterConsumerGroupOffsetsResult;
 import org.apache.kafka.clients.admin.CreateAclsResult;
 import org.apache.kafka.clients.admin.CreatePartitionsResult;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.DeleteAclsResult;
 import org.apache.kafka.clients.admin.DeleteConsumerGroupOffsetsResult;
 import org.apache.kafka.clients.admin.DeleteConsumerGroupsResult;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
@@ -521,10 +522,29 @@ public class KafkaAdminClientImpl implements KafkaAdminClient {
     ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
     Promise<List<AclBinding>> promise = ctx.promise();
 
-    CreateAclsResult createAclsResult = this.adminClient.createAcls(Helper.to(aclBindings));
+    CreateAclsResult createAclsResult = this.adminClient.createAcls(Helper.to2(aclBindings));
     createAclsResult.all().whenComplete((o, ex) -> {
       if (ex == null) {
         promise.complete();
+      } else {
+        promise.fail(ex);
+      }
+    });
+    return promise.future();
+  }
+
+  public void deleteAcls(Collection<AclBindingFilter> aclBindingsFilters, Handler<AsyncResult<List<AclBinding>>> completionHandler) {
+    deleteAcls(aclBindingsFilters).onComplete(completionHandler);
+  }
+
+  public Future<List<AclBinding>> deleteAcls(Collection<AclBindingFilter> aclBindingsFilters) {
+    ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    Promise<List<AclBinding>> promise = ctx.promise();
+
+    DeleteAclsResult deleteAclsResult = this.adminClient.deleteAcls(Helper.to(aclBindingsFilters));
+    deleteAclsResult.all().whenComplete((o, ex) -> {
+      if (ex == null) {
+        promise.complete(Helper.from2(o));
       } else {
         promise.fail(ex);
       }

--- a/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
+++ b/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
@@ -26,6 +26,8 @@ import io.vertx.kafka.admin.MemberAssignment;
 import io.vertx.kafka.admin.NewPartitions;
 import io.vertx.kafka.admin.NewTopic;
 import io.vertx.kafka.admin.OffsetSpec;
+import io.vertx.kafka.admin.PatternType;
+import io.vertx.kafka.admin.ResourcePatternFilter;
 import io.vertx.kafka.client.common.ConfigResource;
 import io.vertx.kafka.client.common.Node;
 import io.vertx.kafka.client.consumer.OffsetAndTimestamp;
@@ -251,5 +253,36 @@ public class Helper {
 
   public static ListOffsetsResultInfo from(org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo lori) {
     return new ListOffsetsResultInfo(lori.offset(), lori.timestamp(), lori.leaderEpoch().orElse(null));
+  }
+
+  public static org.apache.kafka.common.acl.AclBindingFilter to(io.vertx.kafka.admin.AclBindingFilter aclBindingFilter) {
+    return new org.apache.kafka.common.acl.AclBindingFilter(Helper.to(aclBindingFilter.patternFilter()),
+            Helper.to(aclBindingFilter.entryFilter()));
+  }
+
+  private static org.apache.kafka.common.acl.AccessControlEntryFilter to(io.vertx.kafka.admin.AccessControlEntryFilter entryFilter) {
+    return new org.apache.kafka.common.acl.AccessControlEntryFilter(entryFilter.principal(), entryFilter.host(),
+            Helper.to(entryFilter.operation()), Helper.to(entryFilter.permissionType()));
+  }
+
+  private static org.apache.kafka.common.acl.AclPermissionType to(io.vertx.kafka.admin.AclPermissionType permissionType) {
+    return org.apache.kafka.common.acl.AclPermissionType.fromCode(permissionType.code());
+  }
+
+  private static org.apache.kafka.common.acl.AclOperation to(io.vertx.kafka.admin.AclOperation operation) {
+    return org.apache.kafka.common.acl.AclOperation.fromCode(operation.code());
+  }
+
+  private static org.apache.kafka.common.resource.ResourcePatternFilter to(ResourcePatternFilter patternFilter) {
+    return new org.apache.kafka.common.resource.ResourcePatternFilter(Helper.to(patternFilter.resourceType()),
+            patternFilter.name(), Helper.to(patternFilter.patternType()));
+  }
+
+  private static org.apache.kafka.common.resource.PatternType to(PatternType patternType) {
+    return org.apache.kafka.common.resource.PatternType.valueOf(patternType.name());
+  }
+
+  private static org.apache.kafka.common.resource.ResourceType to(io.vertx.kafka.admin.ResourceType resourceType) {
+    return org.apache.kafka.common.resource.ResourceType.fromCode(resourceType.code());
   }
 }

--- a/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
+++ b/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
@@ -19,6 +19,7 @@ package io.vertx.kafka.client.common.impl;
 import io.vertx.core.Handler;
 import io.vertx.kafka.admin.AccessControlEntry;
 import io.vertx.kafka.admin.AclBinding;
+import io.vertx.kafka.admin.AclBindingFilter;
 import io.vertx.kafka.admin.AclOperation;
 import io.vertx.kafka.admin.AclPermissionType;
 import io.vertx.kafka.admin.Config;
@@ -292,8 +293,9 @@ public class Helper {
     return org.apache.kafka.common.resource.ResourceType.fromCode(resourceType.code());
   }
 
-  public static Collection<org.apache.kafka.common.acl.AclBinding> to(Collection<AclBinding> aclBindings) {
-    return aclBindings.stream().map(entry -> new org.apache.kafka.common.acl.AclBinding(Helper.to(entry.pattern()), Helper.to(entry.entry()))).collect(Collectors.toList());
+  public static Collection<org.apache.kafka.common.acl.AclBinding> to2(Collection<AclBinding> aclBindings) {
+    return aclBindings.stream().map(entry -> new org.apache.kafka.common.acl.AclBinding(Helper.to(entry.pattern()),
+                                                                                        Helper.to(entry.entry()))).collect(Collectors.toList());
   }
 
   private static org.apache.kafka.common.acl.AccessControlEntry to(io.vertx.kafka.admin.AccessControlEntry entry) {
@@ -326,5 +328,19 @@ public class Helper {
 
   private static AclOperation from(org.apache.kafka.common.acl.AclOperation operation) {
     return AclOperation.valueOf(operation.name());
+  }
+
+  public static Collection<org.apache.kafka.common.acl.AclBindingFilter> to(Collection<AclBindingFilter> aclBindingsFilters) {
+    return aclBindingsFilters.stream().map(aclBindingsFilter ->
+            new org.apache.kafka.common.acl.AclBindingFilter(Helper.to(aclBindingsFilter.patternFilter()),
+                                                            Helper.to(aclBindingsFilter.entryFilter()))).collect(Collectors.toList());
+  }
+
+  public static List<AclBinding> from2(Collection<org.apache.kafka.common.acl.AclBinding> bindings) {
+    return bindings.stream().map(entry -> Helper.from(entry)).collect(Collectors.toList());
+  }
+
+  private static AclBinding from(org.apache.kafka.common.acl.AclBinding entry) {
+    return new AclBinding(Helper.from(entry.pattern()), Helper.from(entry.entry()));
   }
 }

--- a/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
+++ b/src/main/java/io/vertx/kafka/client/common/impl/Helper.java
@@ -17,6 +17,10 @@
 package io.vertx.kafka.client.common.impl;
 
 import io.vertx.core.Handler;
+import io.vertx.kafka.admin.AccessControlEntry;
+import io.vertx.kafka.admin.AclBinding;
+import io.vertx.kafka.admin.AclOperation;
+import io.vertx.kafka.admin.AclPermissionType;
 import io.vertx.kafka.admin.Config;
 import io.vertx.kafka.admin.ConfigEntry;
 import io.vertx.kafka.admin.ConsumerGroupListing;
@@ -27,7 +31,9 @@ import io.vertx.kafka.admin.NewPartitions;
 import io.vertx.kafka.admin.NewTopic;
 import io.vertx.kafka.admin.OffsetSpec;
 import io.vertx.kafka.admin.PatternType;
+import io.vertx.kafka.admin.ResourcePattern;
 import io.vertx.kafka.admin.ResourcePatternFilter;
+import io.vertx.kafka.admin.ResourceType;
 import io.vertx.kafka.client.common.ConfigResource;
 import io.vertx.kafka.client.common.Node;
 import io.vertx.kafka.client.consumer.OffsetAndTimestamp;
@@ -284,5 +290,41 @@ public class Helper {
 
   private static org.apache.kafka.common.resource.ResourceType to(io.vertx.kafka.admin.ResourceType resourceType) {
     return org.apache.kafka.common.resource.ResourceType.fromCode(resourceType.code());
+  }
+
+  public static Collection<org.apache.kafka.common.acl.AclBinding> to(Collection<AclBinding> aclBindings) {
+    return aclBindings.stream().map(entry -> new org.apache.kafka.common.acl.AclBinding(Helper.to(entry.pattern()), Helper.to(entry.entry()))).collect(Collectors.toList());
+  }
+
+  private static org.apache.kafka.common.acl.AccessControlEntry to(io.vertx.kafka.admin.AccessControlEntry entry) {
+    return new org.apache.kafka.common.acl.AccessControlEntry(entry.principal(), entry.host(), Helper.to(entry.operation()), Helper.to(entry.permissionType()));
+  }
+
+  private static org.apache.kafka.common.resource.ResourcePattern to(ResourcePattern pattern) {
+    return new org.apache.kafka.common.resource.ResourcePattern(Helper.to(pattern.resourceType()), pattern.name(), Helper.to(pattern.patternType()));
+  }
+
+  public static ResourcePattern from(org.apache.kafka.common.resource.ResourcePattern pattern) {
+    return new ResourcePattern(Helper.from(pattern.resourceType()), pattern.name(), Helper.from(pattern.patternType()));
+  }
+
+  private static PatternType from(org.apache.kafka.common.resource.PatternType patternType) {
+    return PatternType.valueOf(patternType.name());
+  }
+
+  private static ResourceType from(org.apache.kafka.common.resource.ResourceType resourceType) {
+    return ResourceType.fromCode(resourceType.code());
+  }
+
+  public static AccessControlEntry from(org.apache.kafka.common.acl.AccessControlEntry entry) {
+    return new AccessControlEntry(entry.principal(), entry.host(), Helper.from(entry.operation()), Helper.from(entry.permissionType()));
+  }
+
+  private static AclPermissionType from(org.apache.kafka.common.acl.AclPermissionType permissionType) {
+    return AclPermissionType.valueOf(permissionType.name());
+  }
+
+  private static AclOperation from(org.apache.kafka.common.acl.AclOperation operation) {
+    return AclOperation.valueOf(operation.name());
   }
 }

--- a/src/test/java/io/vertx/kafka/client/tests/AdminClientAclTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/AdminClientAclTest.java
@@ -92,7 +92,7 @@ public class AdminClientAclTest extends KafkaClusterTestBase {
                     ctx.assertTrue(deleted.get(0).pattern().name().equals(topicName));
                     ctx.assertTrue(deleted.get(0).pattern().patternType().equals(PatternType.LITERAL));
                     ctx.assertTrue(deleted.get(0).pattern().resourceType().equals(ResourceType.TOPIC));
-                    adminClient.describeAcls(abf, ctx.asyncAssertSuccess(list2 -> {
+                    adminClient.describeAcls(abf).onComplete(ctx.asyncAssertSuccess(list2 -> {
                         ctx.assertTrue(list2.isEmpty());
                         adminClient.close();
                     }));

--- a/src/test/java/io/vertx/kafka/client/tests/AdminClientAclTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/AdminClientAclTest.java
@@ -1,0 +1,67 @@
+package io.vertx.kafka.client.tests;
+
+import io.debezium.kafka.KafkaCluster;
+import io.debezium.util.Testing;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.kafka.admin.AccessControlEntryFilter;
+import io.vertx.kafka.admin.AclBindingFilter;
+import io.vertx.kafka.admin.AclOperation;
+import io.vertx.kafka.admin.AclPermissionType;
+import io.vertx.kafka.admin.KafkaAdminClient;
+import io.vertx.kafka.admin.PatternType;
+import io.vertx.kafka.admin.ResourcePatternFilter;
+import io.vertx.kafka.admin.ResourceType;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+public class AdminClientAclTest extends KafkaClusterTestBase {
+    private Vertx vertx;
+    private Properties config;
+    protected static boolean ACL = true;
+
+    private static Set<String> topics = new HashSet<>();
+
+    static {
+        topics.add("first-topic");
+        topics.add("second-topic");
+//    topics.add("offsets-topic");
+    }
+
+    @Before
+    public void beforeTest() {
+        this.vertx = Vertx.vertx();
+        this.config = new Properties();
+        this.config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    }
+
+    @After
+    public void afterTest(TestContext ctx) {
+        this.vertx.close(ctx.asyncAssertSuccess());
+    }
+
+    @BeforeClass
+    public static void setUp() throws IOException {
+        kafkaCluster = kafkaCluster(true).deleteDataPriorToStartup(true).addBrokers(2).startup();
+        kafkaCluster.createTopics(topics);
+    }
+
+    @Test
+    public void testDescribeAcl(TestContext ctx) {
+        KafkaAdminClient adminClient = KafkaAdminClient.create(this.vertx, config);
+        ResourcePatternFilter rpf = new ResourcePatternFilter(ResourceType.TOPIC, "test-acl-topic", PatternType.LITERAL);
+        AccessControlEntryFilter acef = new AccessControlEntryFilter("User:*", "localhost:9092", AclOperation.DESCRIBE, AclPermissionType.ALLOW);
+        adminClient.describeAcls(new AclBindingFilter(rpf, acef), ctx.asyncAssertSuccess(list -> {
+            ctx.assertTrue(list.isEmpty());
+            adminClient.close();
+        }));
+    }
+}

--- a/src/test/java/io/vertx/kafka/client/tests/AdminClientAclTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/AdminClientAclTest.java
@@ -1,7 +1,21 @@
+/*
+ * Copyright 2021 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.vertx.kafka.client.tests;
 
-import io.debezium.kafka.KafkaCluster;
-import io.debezium.util.Testing;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.kafka.admin.AccessControlEntry;
@@ -23,9 +37,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Properties;
-import java.util.Set;
 
 public class AdminClientAclTest extends KafkaClusterTestBase {
     private Vertx vertx;

--- a/src/test/java/io/vertx/kafka/client/tests/AdminClientTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/AdminClientTest.java
@@ -712,8 +712,6 @@ public class AdminClientTest extends KafkaClusterTestBase {
     });
   }
 
-
-
   @Test
   public void testCreatePartitionInTopicWithAssignment(TestContext ctx) throws IOException {
     KafkaAdminClient adminClient = KafkaAdminClient.create(this.vertx, config);

--- a/src/test/java/io/vertx/kafka/client/tests/TransactionalProducerTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/TransactionalProducerTest.java
@@ -51,7 +51,7 @@ public class TransactionalProducerTest extends KafkaClusterTestBase {
   @BeforeClass
   public static void setUp() throws IOException {
     // Override to use 3 broker setup
-    kafkaCluster = kafkaCluster().deleteDataPriorToStartup(true).addBrokers(3).startup();
+    kafkaCluster = kafkaCluster(false).deleteDataPriorToStartup(true).addBrokers(3).startup();
   }
 
   @Before


### PR DESCRIPTION
Motivation:
Kafka AdminClient can create, describe and delete the ACL rules. Vertx kafka client should support these operations as well.

Also fixes https://github.com/vert-x3/vertx-kafka-client/issues/196