### PR TITLE
Documentation typo for receive Kafka message

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -143,7 +143,7 @@ You can add an handler to be notified of the result
 == Receiving messages from a topic requesting specific partitions
 
 Besides being part of a consumer group for receiving messages from a topic, a consumer can ask for a specific
-topic partition. When the consumer is not part part of a consumer group the overall application cannot
+topic partition. When the consumer is not part of a consumer group the overall application cannot
 rely on the re-balancing feature.
 
 You can use {@link io.vertx.kafka.client.consumer.KafkaConsumer#assign(java.util.Set, io.vertx.core.Handler)}


### PR DESCRIPTION
fix document typo

remove duplicate `part`

Motivation:

Found a typo when I tried to translate document to Chinese