### PR TITLE
Update to org.apache.kafka:kafka-clients 2.6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <stack.version>4.2.5-SNAPSHOT</stack.version>
-    <kafka.version>2.6.0</kafka.version>
+    <kafka.version>2.6.3</kafka.version>
     <debezium.version>0.8.3.Final</debezium.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>


### PR DESCRIPTION
Which is the latest of 2.6.x and fixes CVE-2021-26291

Vert.x 4.3.0 will upgrade to the latest Kafka 3
