### PR TITLE
Docs update: Clarify which event loop is used by Kafka Consumer

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -58,6 +58,8 @@ Likewise a producer can be created
 {@link examples.VertxKafkaClientExamples#createProducer}
 ----
 
+NOTE: The event loop that creates the {@link io.vertx.kafka.client.consumer.KafkaConsumer} will be the one to handle its messages. For example if you want messages to be handled on a Verticle's event loop, create the Kafka Consumer within the Verticle's start method.
+
 ifdef::java,groovy,kotlin[]
 Another way is to use a {@link java.util.Properties} instance instead of the map.
 


### PR DESCRIPTION
Motivation:

When using the Kafka Consumer I noticed that the messages were not being handled on the verticle that called `subscribe`, but on a separate event-loop. It wasn't clear to me that the event loop that creates the Kafka Consumer is the one that will handle the messages. I would like to update the documentation to clarify this behaviour.