### PR TITLE
Docs update: Add note on Kafka Consumer tracing

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -490,4 +490,6 @@ span tags are:
 - `peer.service` is always `kafka`
 - `message_bus.destination`, which is set to the topic in use
 
+NOTE: If Vert.x is _not_ configured with Tracing enabled, messages consumed by a Kafka Consumer will _not_ have a unique local context. Keep this in mind if you want to use a context's local data between handlers.
+
 include::admin.adoc[]


### PR DESCRIPTION
Motivation:

So that users don't assume they can rely on a unique local context among handlers during message consumption, can we update the docs with a note? Is it clear enough? Thanks!