### PR TITLE
Fixed name of admin client in the index in doc

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -490,4 +490,4 @@ span tags are:
 - `peer.service` is always `kafka`
 - `message_bus.destination`, which is set to the topic in use
 
-include::admin.adoc[]
+include::adminclient.adoc[]


### PR DESCRIPTION
I found a typo in documentation. Please review @jponge 