### PR TITLE
Upgrade Kafka from 3.0.0 to 3.0.2 fixing CVE-2022-34917

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <stack.version>4.3.4-SNAPSHOT</stack.version>
-    <kafka.version>3.0.0</kafka.version>
+    <kafka.version>3.0.2</kafka.version>
     <debezium.version>1.8.0.Final</debezium.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>


### PR DESCRIPTION
Unauthenticated Kafka clients may cause OutOfMemoryError on Kafka brokers:
https://kafka.apache.org/cve-list#CVE-2022-34917
https://nvd.nist.gov/vuln/detail/CVE-2022-34917

Upgrading Kafka from 3.0.0 to 3.0.2 fixes this vulnerability.