### PR TITLE
(fix) #228: Fixes createPartitions flakiness by waiting a bit for the new partitions to appear in DescribeTopics

### DIFF
--- a/src/test/java/io/vertx/kafka/client/tests/AdminClientTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/AdminClientTest.java
@@ -808,11 +808,13 @@ public class AdminClientTest extends KafkaClusterTestBase {
         ctx.assertTrue(topics.contains("testCreateNewPartitionInTopic"));
 
         adminClient.createPartitions(Collections.singletonMap("testCreateNewPartitionInTopic", new NewPartitions(3, null))).onComplete(ctx.asyncAssertSuccess(v -> {
-          adminClient.describeTopics(Collections.singletonList("testCreateNewPartitionInTopic")).onComplete(ctx.asyncAssertSuccess(s -> {
-            ctx.assertEquals(3, s.get("testCreateNewPartitionInTopic").getPartitions().size());
-            adminClient.close();
-            async.complete();
-          }));
+          vertx.setTimer(500, t2 -> { // although the Future is completed, it takes some time for the change to be reflected in DescribeTopics
+            adminClient.describeTopics(Collections.singletonList("testCreateNewPartitionInTopic")).onComplete(ctx.asyncAssertSuccess(s -> {
+              ctx.assertEquals(3, s.get("testCreateNewPartitionInTopic").getPartitions().size());
+              adminClient.close();
+              async.complete();
+            }));
+          });
         }));
       }));
     });


### PR DESCRIPTION
Motivation:
Attempt at fixing #228  


Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
