### PR TITLE
Upgrade to Kafka 3.4.0, Debezium 2.1.4.Final, JUnit 4.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
 
   <properties>
     <stack.version>5.0.0-SNAPSHOT</stack.version>
-    <kafka.version>3.0.2</kafka.version>
-    <debezium.version>1.8.0.Final</debezium.version>
+    <kafka.version>3.4.0</kafka.version>
+    <debezium.version>2.1.4.Final</debezium.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
 
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/io/vertx/kafka/client/tests/TransactionalProducerTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/TransactionalProducerTest.java
@@ -26,7 +26,6 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.After;
@@ -130,13 +129,13 @@ public class TransactionalProducerTest extends KafkaClusterTestBase {
   @Test
   public void transactionHandlingFailsIfInitWasNotCalled(TestContext ctx) {
     producer.beginTransaction().onComplete(ctx.asyncAssertFailure(cause -> {
-      ctx.assertTrue(cause instanceof KafkaException);
+      ctx.assertTrue(cause instanceof IllegalStateException);
     }));
     producer.commitTransaction().onComplete(ctx.asyncAssertFailure(cause -> {
-      ctx.assertTrue(cause instanceof KafkaException);
+      ctx.assertTrue(cause instanceof IllegalStateException);
     }));
     producer.abortTransaction().onComplete(ctx.asyncAssertFailure(cause -> {
-      ctx.assertTrue(cause instanceof KafkaException);
+      ctx.assertTrue(cause instanceof IllegalStateException);
     }));
   }
 


### PR DESCRIPTION
The upgrade of kafka-client from 3.0.2 to 3.4.0 fixes Deserialization of Untrusted Data:
https://nvd.nist.gov/vuln/detail/CVE-2023-25194