### PR TITLE
Fixes an issue in close handler not forwarding the timeout

### DIFF
--- a/src/main/java/io/vertx/kafka/client/producer/impl/KafkaProducerImpl.java
+++ b/src/main/java/io/vertx/kafka/client/producer/impl/KafkaProducerImpl.java
@@ -295,7 +295,7 @@ public class KafkaProducerImpl<K, V> implements KafkaProducer<K, V> {
 
   @Override
   public void close(long timeout, Handler<AsyncResult<Void>> completionHandler) {
-    closeHandler.close(completionHandler);
+    closeHandler.close(timeout, completionHandler);
   }
 
   @Override

--- a/src/main/java/io/vertx/kafka/client/producer/impl/KafkaProducerImpl.java
+++ b/src/main/java/io/vertx/kafka/client/producer/impl/KafkaProducerImpl.java
@@ -16,18 +16,13 @@
 
 package io.vertx.kafka.client.producer.impl;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
+import io.vertx.core.*;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.kafka.client.common.KafkaClientOptions;
+import io.vertx.kafka.client.common.PartitionInfo;
 import io.vertx.kafka.client.common.impl.CloseHandler;
 import io.vertx.kafka.client.common.impl.Helper;
-import io.vertx.kafka.client.common.PartitionInfo;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import io.vertx.kafka.client.producer.KafkaWriteStream;
@@ -35,7 +30,6 @@ import io.vertx.kafka.client.producer.RecordMetadata;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.serialization.Serializer;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Motivation:

As reported on Discord: https://discord.com/channels/751380286071242794/751398291874512967/1097519534753198150 

There seems to be a bug of KafkaProducerWriteImpl not forwarding the timeout to the close handler.

I have been able to reproduce in the new added test (revert line 298 of KafkaProducerImpl and the test won't pass) and fix it.