### PR TITLE
Upgrade to Kafka 3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <stack.version>5.0.0-SNAPSHOT</stack.version>
-    <kafka.version>3.0.2</kafka.version>
+    <kafka.version>3.4.0</kafka.version>
     <debezium.version>1.8.0.Final</debezium.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>

--- a/src/test/java/io/vertx/kafka/client/tests/TransactionalProducerTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/TransactionalProducerTest.java
@@ -130,13 +130,13 @@ public class TransactionalProducerTest extends KafkaClusterTestBase {
   @Test
   public void transactionHandlingFailsIfInitWasNotCalled(TestContext ctx) {
     producer.beginTransaction().onComplete(ctx.asyncAssertFailure(cause -> {
-      ctx.assertTrue(cause instanceof KafkaException);
+      ctx.assertTrue(cause instanceof IllegalStateException);
     }));
     producer.commitTransaction().onComplete(ctx.asyncAssertFailure(cause -> {
-      ctx.assertTrue(cause instanceof KafkaException);
+      ctx.assertTrue(cause instanceof IllegalStateException);
     }));
     producer.abortTransaction().onComplete(ctx.asyncAssertFailure(cause -> {
-      ctx.assertTrue(cause instanceof KafkaException);
+      ctx.assertTrue(cause instanceof IllegalStateException);
     }));
   }
 


### PR DESCRIPTION
Motivation:

Upgrade Kafka to v3.4.0

---

Should we bump the project version in pom, too, or is there a dedicated CI process for versioning?
