### PR TITLE
Remove unnecessary timer

### DIFF
--- a/src/main/java/io/vertx/kafka/client/producer/impl/KafkaWriteStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/producer/impl/KafkaWriteStreamImpl.java
@@ -186,20 +186,11 @@ public class KafkaWriteStreamImpl<K, V> implements KafkaWriteStream<K, V> {
   @Override
   public Future<List<PartitionInfo>> partitionsFor(String topic) {
     ContextInternal ctx = vertx.getOrCreateContext();
-    Promise<List<PartitionInfo>> trampolineProm = ctx.promise();
-
-    // TODO: should be this timeout related to the Kafka producer property "metadata.fetch.timeout.ms" ?
-    this.vertx.setTimer(2000, id -> {
-      trampolineProm.tryFail("Kafka connect timeout");
-    });
-
-    ctx.<List<PartitionInfo>>executeBlocking(prom -> {
+    return ctx.<List<PartitionInfo>>executeBlocking(prom -> {
       prom.complete(
         this.producer.partitionsFor(topic)
       );
-    }, taskQueue).onComplete(trampolineProm);
-
-    return trampolineProm.future(); // Trampoline on caller context
+    }, taskQueue);
   }
 
   @Override

--- a/src/test/java/io/vertx/kafka/client/tests/NoClusterTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/NoClusterTest.java
@@ -1,0 +1,73 @@
+package io.vertx.kafka.client.tests;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.kafka.client.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RunWith(VertxUnitRunner.class)
+public class NoClusterTest {
+
+  private Vertx vertx;
+
+  @Before
+  public void setUpVertx() {
+    vertx = Vertx.vertx();
+  }
+
+  @After
+  public void tearDownVertx(TestContext ctx) {
+    vertx.close()
+      .onFailure(ctx::fail)
+      .onComplete(ctx.asyncAssertSuccess());
+    vertx = null;
+  }
+
+  @Test
+  public void partitionsForTimeoutMaxBlockMsHigh(TestContext ctx) {
+    long maxBlockMs = 2_100; // > the arbitrary hardcoded timeout of 2s
+    Properties props = new Properties() {{
+      put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:1234");
+      put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+      put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+      put(ProducerConfig.MAX_BLOCK_MS_CONFIG, maxBlockMs); // this should trigger the timeout
+    }};
+    KafkaProducer<String, String> producer = KafkaProducer.create(vertx, props);
+    Async async = ctx.async();
+    producer.partitionsFor("doesnotexist")
+      .onFailure(t -> {
+        ctx.assertTrue(t instanceof TimeoutException); // used to fail, since the problem
+        async.complete();
+      });
+  }
+
+  @Test
+  public void partitionsForTimeoutMaxBlockMsLow(TestContext ctx) {
+    long maxBlockMs = 5; // < the arbitrary hardcoded timeout of 2s -> this test always worked, before the timer got removed
+    Properties props = new Properties() {{
+      put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:1234");
+      put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+      put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+      put(ProducerConfig.MAX_BLOCK_MS_CONFIG, maxBlockMs); // this should trigger the timeout
+    }};
+    KafkaProducer<String, String> producer = KafkaProducer.create(vertx, props);
+    Async async = ctx.async();
+    producer.partitionsFor("doesnotexist")
+      .onFailure(t -> {
+        ctx.assertTrue(t instanceof TimeoutException);
+        async.complete();
+      });
+  }
+
+}


### PR DESCRIPTION
The call to Kafka producer's `partitionFor` will fail when `max.block.ms` duration is reached.
Fixes #59 and replaces #121 
 

Motivation:

Not sure why this `setTimer` had been implemented in the first place, maybe `max.block.ms` did not exist at the time, but this is no longer needed.

Calls to `producer.send(...)` `producer.partitionsFor(...)` are subject to the `max.block.ms` configuration parameter, and a `TimeoutException` will be fired past this duration.

Although the failure no longer gets fired twice (like mentioned before in #59 ), it could introduce some issue in cases the cluster is slow, or network is slow. Say an user HAS to configure `max.block.ms` to a value greater than 2000, the hardcoded `setTimer` would fire BEFORE `max.block.ms` gets reached, which could block some users.
