### PR TITLE
Fixes #156: generate subscribe(Pattern) in JVM clients

### DIFF
--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
@@ -277,7 +277,7 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
    * @param pattern  Pattern to subscribe to
    * @return a {@code Future} completed with the operation result
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Future<Void> subscribe(Pattern pattern);
 
   /**


### PR DESCRIPTION
Motivation:

As mentioned in #156 : allow JVM clients (rxJava, etc.) to use  `subscribe(Pattern)`
From vertx-codegen: 
```
We define _`JavaType`_ as the set of any Java type that does not belong to _`Basic`_, _`Json`_, _`DataObject`_, _`TypeVar`_ and _`Api`_, e.g `java.net.Socket`. 
Methods are not allowed to declare such type by default and can be annotated with `@GenIgnore(GenIgnore.PERMITTED_TYPE)` to allow them. Such
method limit the translation of the method to other languages, so it should be used with care. It is useful to allow method
previously annotated with `@GenIgnore` to be available in code generator like RxJava that can handle Java types.
```

`java.util.regex.Pattern` seems to fall pretty nicely into that `JavaType` bucket. 
