### PR TITLE
Fix KafkaClientOptions.toJson() so JsonObject includes config contents

### DIFF
--- a/src/main/java/io/vertx/kafka/client/common/KafkaClientOptions.java
+++ b/src/main/java/io/vertx/kafka/client/common/KafkaClientOptions.java
@@ -145,6 +145,6 @@ public class KafkaClientOptions {
   }
 
   public JsonObject toJson() {
-    return new JsonObject();
+    return new JsonObject(config);
   }
 }


### PR DESCRIPTION
fix KafkaClientOptions.toJson() so the JsonObject includes the config contents

Motivation:

At present KafkaClientOptions.toJson() always returns an empty JsonObject, even if the config map is not empty. This PR fixes that, so that the returned JsonObject reflects what's in the config map.
