### PR TITLE
Fix KafkaClientOptions.toJson() so JsonObject includes config contents

### DIFF
--- a/src/main/java/io/vertx/kafka/client/common/KafkaClientOptions.java
+++ b/src/main/java/io/vertx/kafka/client/common/KafkaClientOptions.java
@@ -145,6 +145,6 @@ public class KafkaClientOptions {
   }
 
   public JsonObject toJson() {
-    return new JsonObject();
+    return new JsonObject(config);
   }
 }


### PR DESCRIPTION
Motivation:

At present KafkaClientOptions.toJson() always returns an empty JsonObject, even if the config map is not empty. This PR fixes that, so that the returned JsonObject reflects what's in the config map.

As requested by @vietj via https://github.com/vert-x3/vertx-kafka-client/pull/247#issuecomment-1593023227, this PR is a port of PR #247 to the 4.x branch.