### PR TITLE
Fix issue with batchHandler not being called without also using handler

### DIFF
--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaReadStreamImpl.java
@@ -181,23 +181,24 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
 
   private void schedule(long delay) {
     Handler<ConsumerRecord<K, V>> handler = this.recordHandler;
+    Handler<ConsumerRecords<K, V>> multiHandler = this.batchHandler;
 
     if (this.consuming.get()
         && this.demand.get() > 0L
-        && handler != null) {
+        && (handler != null || batchHandler != null)) {
 
       this.context.runOnContext(v1 -> {
         if (delay > 0) {
-          this.context.owner().setTimer(delay, v2 -> run(handler));
+          this.context.owner().setTimer(delay, v2 -> run(handler, multiHandler));
         } else {
-          run(handler);
+          run(handler, multiHandler);
         }
       });
     }
   }
 
   // Access the consumer from the event loop since the consumer is not thread safe
-  private void run(Handler<ConsumerRecord<K, V>> handler) {
+  private void run(Handler<ConsumerRecord<K, V>> handler, Handler<ConsumerRecords<K, V>> multiHandler) {
 
     if (this.closed.get()) {
       return;
@@ -209,8 +210,8 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
 
         if (records != null && records.count() > 0) {
           this.current = records.iterator();
-          if (batchHandler != null) {
-            batchHandler.handle(records);
+          if (multiHandler != null) {
+            multiHandler.handle(records);
           }
           this.schedule(0);
         } else {
@@ -690,6 +691,7 @@ public class KafkaReadStreamImpl<K, V> implements KafkaReadStream<K, V> {
 
   public KafkaReadStream batchHandler(Handler<ConsumerRecords<K, V>> handler) {
     this.batchHandler = handler;
+    this.schedule(0);
     return this;
   }
 

--- a/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
@@ -1358,7 +1358,6 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
       }
       batchHandler.complete();
     });
-    wrappedConsumer.handler(rec -> {});
     wrappedConsumer.subscribe(Collections.singleton(topicName));
   }
 


### PR DESCRIPTION
Motivation:

The Kafka Client API provides two ways of processing records, using the `handler` and `batchHandler` methods.
It turns out that `batchHandler` cannot be used independently in the current implementation, since a call to `handler` (even if the function itself does nothing) is required in order for the `batchHandler` to be called.

The same issue in #170.

This fix changes the following:
- null check on `schedule` now takes into account both handler types
- to preserve the same guarantees provided for `handler`, the `batchHandler` reference is now captured in `schedule` and passed down to the `run` method.
- the test for `batchHandler` no longer calls `handler` (verified that this makes the test time out without the actual fix)

The name `multiHandler` on the `schedule` method is not great but I didn't want to shadow the field name, I'm open to suggestions.