### PR TITLE
[4.4] Upgrade kafka-clients to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <stack.version>4.4.6-SNAPSHOT</stack.version>
-    <kafka.version>3.0.2</kafka.version>
+    <kafka.version>3.5.0</kafka.version>
     <debezium.version>1.8.0.Final</debezium.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>


### PR DESCRIPTION
Motivation:

Upgrade kafka-clients to 3.5.0 to fix CVE-2023-34455 (snappy-java).

Conformance: **Done** 

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
