### PR TITLE
Upgrade kafka-clients from 3.5.0 to 3.6.0 fixing snappy vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
 
   <properties>
     <stack.version>5.0.0-SNAPSHOT</stack.version>
-    <kafka.version>3.5.0</kafka.version>
-    <debezium.version>2.1.4.Final</debezium.version>
+    <kafka.version>3.6.0</kafka.version>
+    <debezium.version>2.5.0.Alpha2</debezium.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
 

--- a/src/main/generated/io/vertx/kafka/admin/ClusterDescriptionConverter.java
+++ b/src/main/generated/io/vertx/kafka/admin/ClusterDescriptionConverter.java
@@ -20,26 +20,6 @@ public class ClusterDescriptionConverter {
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ClusterDescription obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
-        case "authorizedOperations":
-          if (member.getValue() instanceof JsonArray) {
-            java.util.LinkedHashSet<org.apache.kafka.common.acl.AclOperation> list =  new java.util.LinkedHashSet<>();
-            ((Iterable<Object>)member.getValue()).forEach( item -> {
-              if (item instanceof String)
-                list.add(org.apache.kafka.common.acl.AclOperation.valueOf((String)item));
-            });
-            obj.setAuthorizedOperations(list);
-          }
-          break;
-        case "clusterId":
-          if (member.getValue() instanceof String) {
-            obj.setClusterId((String)member.getValue());
-          }
-          break;
-        case "controller":
-          if (member.getValue() instanceof JsonObject) {
-            obj.setController(new io.vertx.kafka.client.common.Node((io.vertx.core.json.JsonObject)member.getValue()));
-          }
-          break;
         case "nodes":
           if (member.getValue() instanceof JsonArray) {
             java.util.ArrayList<io.vertx.kafka.client.common.Node> list =  new java.util.ArrayList<>();
@@ -48,6 +28,26 @@ public class ClusterDescriptionConverter {
                 list.add(new io.vertx.kafka.client.common.Node((io.vertx.core.json.JsonObject)item));
             });
             obj.setNodes(list);
+          }
+          break;
+        case "controller":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setController(new io.vertx.kafka.client.common.Node((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
+        case "clusterId":
+          if (member.getValue() instanceof String) {
+            obj.setClusterId((String)member.getValue());
+          }
+          break;
+        case "authorizedOperations":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.LinkedHashSet<org.apache.kafka.common.acl.AclOperation> list =  new java.util.LinkedHashSet<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                list.add(org.apache.kafka.common.acl.AclOperation.valueOf((String)item));
+            });
+            obj.setAuthorizedOperations(list);
           }
           break;
       }
@@ -59,21 +59,21 @@ public class ClusterDescriptionConverter {
   }
 
   public static void toJson(ClusterDescription obj, java.util.Map<String, Object> json) {
-    if (obj.getAuthorizedOperations() != null) {
-      JsonArray array = new JsonArray();
-      obj.getAuthorizedOperations().forEach(item -> array.add(item.name()));
-      json.put("authorizedOperations", array);
-    }
-    if (obj.getClusterId() != null) {
-      json.put("clusterId", obj.getClusterId());
-    }
-    if (obj.getController() != null) {
-      json.put("controller", obj.getController().toJson());
-    }
     if (obj.getNodes() != null) {
       JsonArray array = new JsonArray();
       obj.getNodes().forEach(item -> array.add(item.toJson()));
       json.put("nodes", array);
+    }
+    if (obj.getController() != null) {
+      json.put("controller", obj.getController().toJson());
+    }
+    if (obj.getClusterId() != null) {
+      json.put("clusterId", obj.getClusterId());
+    }
+    if (obj.getAuthorizedOperations() != null) {
+      JsonArray array = new JsonArray();
+      obj.getAuthorizedOperations().forEach(item -> array.add(item.name()));
+      json.put("authorizedOperations", array);
     }
   }
 }

--- a/src/main/generated/io/vertx/kafka/admin/ConfigEntryConverter.java
+++ b/src/main/generated/io/vertx/kafka/admin/ConfigEntryConverter.java
@@ -20,14 +20,14 @@ public class ConfigEntryConverter {
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ConfigEntry obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
-        case "default":
-          if (member.getValue() instanceof Boolean) {
-            obj.setDefault((Boolean)member.getValue());
-          }
-          break;
         case "name":
           if (member.getValue() instanceof String) {
             obj.setName((String)member.getValue());
+          }
+          break;
+        case "default":
+          if (member.getValue() instanceof Boolean) {
+            obj.setDefault((Boolean)member.getValue());
           }
           break;
         case "readOnly":
@@ -69,10 +69,10 @@ public class ConfigEntryConverter {
   }
 
   public static void toJson(ConfigEntry obj, java.util.Map<String, Object> json) {
-    json.put("default", obj.isDefault());
     if (obj.getName() != null) {
       json.put("name", obj.getName());
     }
+    json.put("default", obj.isDefault());
     json.put("readOnly", obj.isReadOnly());
     json.put("sensitive", obj.isSensitive());
     if (obj.getSource() != null) {

--- a/src/main/generated/io/vertx/kafka/admin/ConfigSynonymConverter.java
+++ b/src/main/generated/io/vertx/kafka/admin/ConfigSynonymConverter.java
@@ -25,14 +25,14 @@ public class ConfigSynonymConverter {
             obj.setName((String)member.getValue());
           }
           break;
-        case "source":
-          if (member.getValue() instanceof String) {
-            obj.setSource(org.apache.kafka.clients.admin.ConfigEntry.ConfigSource.valueOf((String)member.getValue()));
-          }
-          break;
         case "value":
           if (member.getValue() instanceof String) {
             obj.setValue((String)member.getValue());
+          }
+          break;
+        case "source":
+          if (member.getValue() instanceof String) {
+            obj.setSource(org.apache.kafka.clients.admin.ConfigEntry.ConfigSource.valueOf((String)member.getValue()));
           }
           break;
       }
@@ -47,11 +47,11 @@ public class ConfigSynonymConverter {
     if (obj.getName() != null) {
       json.put("name", obj.getName());
     }
-    if (obj.getSource() != null) {
-      json.put("source", obj.getSource().name());
-    }
     if (obj.getValue() != null) {
       json.put("value", obj.getValue());
+    }
+    if (obj.getSource() != null) {
+      json.put("source", obj.getSource().name());
     }
   }
 }

--- a/src/main/generated/io/vertx/kafka/admin/ConsumerGroupDescriptionConverter.java
+++ b/src/main/generated/io/vertx/kafka/admin/ConsumerGroupDescriptionConverter.java
@@ -20,24 +20,19 @@ public class ConsumerGroupDescriptionConverter {
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ConsumerGroupDescription obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
-        case "authorizedOperations":
-          if (member.getValue() instanceof JsonArray) {
-            java.util.LinkedHashSet<org.apache.kafka.common.acl.AclOperation> list =  new java.util.LinkedHashSet<>();
-            ((Iterable<Object>)member.getValue()).forEach( item -> {
-              if (item instanceof String)
-                list.add(org.apache.kafka.common.acl.AclOperation.valueOf((String)item));
-            });
-            obj.setAuthorizedOperations(list);
+        case "groupId":
+          if (member.getValue() instanceof String) {
+            obj.setGroupId((String)member.getValue());
+          }
+          break;
+        case "simpleConsumerGroup":
+          if (member.getValue() instanceof Boolean) {
+            obj.setSimpleConsumerGroup((Boolean)member.getValue());
           }
           break;
         case "coordinator":
           if (member.getValue() instanceof JsonObject) {
             obj.setCoordinator(new io.vertx.kafka.client.common.Node((io.vertx.core.json.JsonObject)member.getValue()));
-          }
-          break;
-        case "groupId":
-          if (member.getValue() instanceof String) {
-            obj.setGroupId((String)member.getValue());
           }
           break;
         case "members":
@@ -55,14 +50,19 @@ public class ConsumerGroupDescriptionConverter {
             obj.setPartitionAssignor((String)member.getValue());
           }
           break;
-        case "simpleConsumerGroup":
-          if (member.getValue() instanceof Boolean) {
-            obj.setSimpleConsumerGroup((Boolean)member.getValue());
-          }
-          break;
         case "state":
           if (member.getValue() instanceof String) {
             obj.setState(org.apache.kafka.common.ConsumerGroupState.valueOf((String)member.getValue()));
+          }
+          break;
+        case "authorizedOperations":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.LinkedHashSet<org.apache.kafka.common.acl.AclOperation> list =  new java.util.LinkedHashSet<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                list.add(org.apache.kafka.common.acl.AclOperation.valueOf((String)item));
+            });
+            obj.setAuthorizedOperations(list);
           }
           break;
       }
@@ -74,16 +74,12 @@ public class ConsumerGroupDescriptionConverter {
   }
 
   public static void toJson(ConsumerGroupDescription obj, java.util.Map<String, Object> json) {
-    if (obj.getAuthorizedOperations() != null) {
-      JsonArray array = new JsonArray();
-      obj.getAuthorizedOperations().forEach(item -> array.add(item.name()));
-      json.put("authorizedOperations", array);
-    }
-    if (obj.getCoordinator() != null) {
-      json.put("coordinator", obj.getCoordinator().toJson());
-    }
     if (obj.getGroupId() != null) {
       json.put("groupId", obj.getGroupId());
+    }
+    json.put("simpleConsumerGroup", obj.isSimpleConsumerGroup());
+    if (obj.getCoordinator() != null) {
+      json.put("coordinator", obj.getCoordinator().toJson());
     }
     if (obj.getMembers() != null) {
       JsonArray array = new JsonArray();
@@ -93,9 +89,13 @@ public class ConsumerGroupDescriptionConverter {
     if (obj.getPartitionAssignor() != null) {
       json.put("partitionAssignor", obj.getPartitionAssignor());
     }
-    json.put("simpleConsumerGroup", obj.isSimpleConsumerGroup());
     if (obj.getState() != null) {
       json.put("state", obj.getState().name());
+    }
+    if (obj.getAuthorizedOperations() != null) {
+      JsonArray array = new JsonArray();
+      obj.getAuthorizedOperations().forEach(item -> array.add(item.name()));
+      json.put("authorizedOperations", array);
     }
   }
 }

--- a/src/main/generated/io/vertx/kafka/admin/ListOffsetsResultInfoConverter.java
+++ b/src/main/generated/io/vertx/kafka/admin/ListOffsetsResultInfoConverter.java
@@ -20,11 +20,6 @@ public class ListOffsetsResultInfoConverter {
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ListOffsetsResultInfo obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
-        case "leaderEpoch":
-          if (member.getValue() instanceof Number) {
-            obj.setLeaderEpoch(((Number)member.getValue()).intValue());
-          }
-          break;
         case "offset":
           if (member.getValue() instanceof Number) {
             obj.setOffset(((Number)member.getValue()).longValue());
@@ -33,6 +28,11 @@ public class ListOffsetsResultInfoConverter {
         case "timestamp":
           if (member.getValue() instanceof Number) {
             obj.setTimestamp(((Number)member.getValue()).longValue());
+          }
+          break;
+        case "leaderEpoch":
+          if (member.getValue() instanceof Number) {
+            obj.setLeaderEpoch(((Number)member.getValue()).intValue());
           }
           break;
       }
@@ -44,10 +44,10 @@ public class ListOffsetsResultInfoConverter {
   }
 
   public static void toJson(ListOffsetsResultInfo obj, java.util.Map<String, Object> json) {
+    json.put("offset", obj.getOffset());
+    json.put("timestamp", obj.getTimestamp());
     if (obj.getLeaderEpoch() != null) {
       json.put("leaderEpoch", obj.getLeaderEpoch());
     }
-    json.put("offset", obj.getOffset());
-    json.put("timestamp", obj.getTimestamp());
   }
 }

--- a/src/main/generated/io/vertx/kafka/admin/MemberDescriptionConverter.java
+++ b/src/main/generated/io/vertx/kafka/admin/MemberDescriptionConverter.java
@@ -20,9 +20,9 @@ public class MemberDescriptionConverter {
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, MemberDescription obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
-        case "assignment":
-          if (member.getValue() instanceof JsonObject) {
-            obj.setAssignment(new io.vertx.kafka.admin.MemberAssignment((io.vertx.core.json.JsonObject)member.getValue()));
+        case "consumerId":
+          if (member.getValue() instanceof String) {
+            obj.setConsumerId((String)member.getValue());
           }
           break;
         case "clientId":
@@ -30,9 +30,9 @@ public class MemberDescriptionConverter {
             obj.setClientId((String)member.getValue());
           }
           break;
-        case "consumerId":
-          if (member.getValue() instanceof String) {
-            obj.setConsumerId((String)member.getValue());
+        case "assignment":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setAssignment(new io.vertx.kafka.admin.MemberAssignment((io.vertx.core.json.JsonObject)member.getValue()));
           }
           break;
         case "host":
@@ -49,14 +49,14 @@ public class MemberDescriptionConverter {
   }
 
   public static void toJson(MemberDescription obj, java.util.Map<String, Object> json) {
-    if (obj.getAssignment() != null) {
-      json.put("assignment", obj.getAssignment().toJson());
+    if (obj.getConsumerId() != null) {
+      json.put("consumerId", obj.getConsumerId());
     }
     if (obj.getClientId() != null) {
       json.put("clientId", obj.getClientId());
     }
-    if (obj.getConsumerId() != null) {
-      json.put("consumerId", obj.getConsumerId());
+    if (obj.getAssignment() != null) {
+      json.put("assignment", obj.getAssignment().toJson());
     }
     if (obj.getHost() != null) {
       json.put("host", obj.getHost());

--- a/src/main/generated/io/vertx/kafka/admin/NewTopicConverter.java
+++ b/src/main/generated/io/vertx/kafka/admin/NewTopicConverter.java
@@ -20,16 +20,6 @@ public class NewTopicConverter {
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, NewTopic obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
-        case "config":
-          if (member.getValue() instanceof JsonObject) {
-            java.util.Map<String, java.lang.String> map = new java.util.LinkedHashMap<>();
-            ((Iterable<java.util.Map.Entry<String, Object>>)member.getValue()).forEach(entry -> {
-              if (entry.getValue() instanceof String)
-                map.put(entry.getKey(), (String)entry.getValue());
-            });
-            obj.setConfig(map);
-          }
-          break;
         case "name":
           if (member.getValue() instanceof String) {
             obj.setName((String)member.getValue());
@@ -45,6 +35,16 @@ public class NewTopicConverter {
             obj.setReplicationFactor(((Number)member.getValue()).shortValue());
           }
           break;
+        case "config":
+          if (member.getValue() instanceof JsonObject) {
+            java.util.Map<String, java.lang.String> map = new java.util.LinkedHashMap<>();
+            ((Iterable<java.util.Map.Entry<String, Object>>)member.getValue()).forEach(entry -> {
+              if (entry.getValue() instanceof String)
+                map.put(entry.getKey(), (String)entry.getValue());
+            });
+            obj.setConfig(map);
+          }
+          break;
       }
     }
   }
@@ -54,15 +54,15 @@ public class NewTopicConverter {
   }
 
   public static void toJson(NewTopic obj, java.util.Map<String, Object> json) {
-    if (obj.getConfig() != null) {
-      JsonObject map = new JsonObject();
-      obj.getConfig().forEach((key, value) -> map.put(key, value));
-      json.put("config", map);
-    }
     if (obj.getName() != null) {
       json.put("name", obj.getName());
     }
     json.put("numPartitions", obj.getNumPartitions());
     json.put("replicationFactor", obj.getReplicationFactor());
+    if (obj.getConfig() != null) {
+      JsonObject map = new JsonObject();
+      obj.getConfig().forEach((key, value) -> map.put(key, value));
+      json.put("config", map);
+    }
   }
 }

--- a/src/main/generated/io/vertx/kafka/admin/TopicDescriptionConverter.java
+++ b/src/main/generated/io/vertx/kafka/admin/TopicDescriptionConverter.java
@@ -20,16 +20,6 @@ public class TopicDescriptionConverter {
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, TopicDescription obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
-        case "authorizedOperations":
-          if (member.getValue() instanceof JsonArray) {
-            java.util.LinkedHashSet<org.apache.kafka.common.acl.AclOperation> list =  new java.util.LinkedHashSet<>();
-            ((Iterable<Object>)member.getValue()).forEach( item -> {
-              if (item instanceof String)
-                list.add(org.apache.kafka.common.acl.AclOperation.valueOf((String)item));
-            });
-            obj.setAuthorizedOperations(list);
-          }
-          break;
         case "internal":
           if (member.getValue() instanceof Boolean) {
             obj.setInternal((Boolean)member.getValue());
@@ -38,6 +28,16 @@ public class TopicDescriptionConverter {
         case "name":
           if (member.getValue() instanceof String) {
             obj.setName((String)member.getValue());
+          }
+          break;
+        case "authorizedOperations":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.LinkedHashSet<org.apache.kafka.common.acl.AclOperation> list =  new java.util.LinkedHashSet<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                list.add(org.apache.kafka.common.acl.AclOperation.valueOf((String)item));
+            });
+            obj.setAuthorizedOperations(list);
           }
           break;
         case "partitions":
@@ -59,14 +59,14 @@ public class TopicDescriptionConverter {
   }
 
   public static void toJson(TopicDescription obj, java.util.Map<String, Object> json) {
+    json.put("internal", obj.isInternal());
+    if (obj.getName() != null) {
+      json.put("name", obj.getName());
+    }
     if (obj.getAuthorizedOperations() != null) {
       JsonArray array = new JsonArray();
       obj.getAuthorizedOperations().forEach(item -> array.add(item.name()));
       json.put("authorizedOperations", array);
-    }
-    json.put("internal", obj.isInternal());
-    if (obj.getName() != null) {
-      json.put("name", obj.getName());
     }
     if (obj.getPartitions() != null) {
       JsonArray array = new JsonArray();

--- a/src/main/generated/io/vertx/kafka/client/common/ConfigResourceConverter.java
+++ b/src/main/generated/io/vertx/kafka/client/common/ConfigResourceConverter.java
@@ -20,14 +20,14 @@ public class ConfigResourceConverter {
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ConfigResource obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
-        case "default":
-          if (member.getValue() instanceof Boolean) {
-            obj.setDefault((Boolean)member.getValue());
-          }
-          break;
         case "name":
           if (member.getValue() instanceof String) {
             obj.setName((String)member.getValue());
+          }
+          break;
+        case "default":
+          if (member.getValue() instanceof Boolean) {
+            obj.setDefault((Boolean)member.getValue());
           }
           break;
         case "type":
@@ -44,10 +44,10 @@ public class ConfigResourceConverter {
   }
 
   public static void toJson(ConfigResource obj, java.util.Map<String, Object> json) {
-    json.put("default", obj.isDefault());
     if (obj.getName() != null) {
       json.put("name", obj.getName());
     }
+    json.put("default", obj.isDefault());
     if (obj.getType() != null) {
       json.put("type", obj.getType().name());
     }

--- a/src/main/generated/io/vertx/kafka/client/common/KafkaClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/kafka/client/common/KafkaClientOptionsConverter.java
@@ -30,14 +30,14 @@ public class KafkaClientOptionsConverter {
             obj.setConfig(map);
           }
           break;
-        case "tracePeerAddress":
-          if (member.getValue() instanceof String) {
-            obj.setTracePeerAddress((String)member.getValue());
-          }
-          break;
         case "tracingPolicy":
           if (member.getValue() instanceof String) {
             obj.setTracingPolicy(io.vertx.core.tracing.TracingPolicy.valueOf((String)member.getValue()));
+          }
+          break;
+        case "tracePeerAddress":
+          if (member.getValue() instanceof String) {
+            obj.setTracePeerAddress((String)member.getValue());
           }
           break;
       }
@@ -54,11 +54,11 @@ public class KafkaClientOptionsConverter {
       obj.getConfig().forEach((key, value) -> map.put(key, value));
       json.put("config", map);
     }
-    if (obj.getTracePeerAddress() != null) {
-      json.put("tracePeerAddress", obj.getTracePeerAddress());
-    }
     if (obj.getTracingPolicy() != null) {
       json.put("tracingPolicy", obj.getTracingPolicy().name());
+    }
+    if (obj.getTracePeerAddress() != null) {
+      json.put("tracePeerAddress", obj.getTracePeerAddress());
     }
   }
 }


### PR DESCRIPTION
The kafka-clients upgrade indirectly upgrades snappy-java from 1.1.10.0 to 1.1.10.4 fixing these snappy-java vulnerablities:
* https://nvd.nist.gov/vuln/detail/CVE-2023-34453
* https://nvd.nist.gov/vuln/detail/CVE-2023-34454
* https://nvd.nist.gov/vuln/detail/CVE-2023-34455
* https://nvd.nist.gov/vuln/detail/CVE-2023-43642

kafka-clients 3.6.0 requires to bump the test dependency debezium from 2.1.4.Final to 2.5.0.Alpha2.