### PR TITLE
Let users define tracing options in all cases

### DIFF
--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaConsumer.java
@@ -31,12 +31,10 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.serialization.Deserializer;
 
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Pattern;
+
+import static io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE;
 
 /**
  * Vert.x Kafka consumer.
@@ -55,13 +53,27 @@ public interface KafkaConsumer<K, V> extends ReadStream<KafkaConsumerRecord<K, V
   /**
    * Create a new KafkaConsumer instance from a native {@link Consumer}.
    *
-   * @param vertx Vert.x instance to use
+   * @param vertx    Vert.x instance to use
    * @param consumer the Kafka consumer to wrap
-   * @return  an instance of the KafkaConsumer
+   * @return an instance of the KafkaConsumer
    */
-  @GenIgnore
+  @GenIgnore(PERMITTED_TYPE)
   static <K, V> KafkaConsumer<K, V> create(Vertx vertx, Consumer<K, V> consumer) {
     KafkaReadStream<K, V> stream = KafkaReadStream.create(vertx, consumer);
+    return new KafkaConsumerImpl<>(stream);
+  }
+
+  /**
+   * Create a new KafkaConsumer instance from a native {@link Consumer}.
+   *
+   * @param vertx    Vert.x instance to use
+   * @param consumer the Kafka consumer to wrap
+   * @param options  options used only for tracing settings
+   * @return an instance of the KafkaConsumer
+   */
+  @GenIgnore(PERMITTED_TYPE)
+  static <K, V> KafkaConsumer<K, V> create(Vertx vertx, Consumer<K, V> consumer, KafkaClientOptions options) {
+    KafkaReadStream<K, V> stream = KafkaReadStream.create(vertx, consumer, options);
     return new KafkaConsumerImpl<>(stream);
   }
 

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaReadStream.java
@@ -24,21 +24,15 @@ import io.vertx.core.streams.ReadStream;
 import io.vertx.kafka.client.common.KafkaClientOptions;
 import io.vertx.kafka.client.consumer.impl.KafkaReadStreamImpl;
 import io.vertx.kafka.client.serialization.VertxSerdes;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Deserializer;
 
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Pattern;
 
 /**
@@ -230,7 +224,19 @@ public interface KafkaReadStream<K, V> extends ReadStream<ConsumerRecord<K, V>> 
    * @return an instance of the KafkaReadStream
    */
   static <K, V> KafkaReadStream<K, V> create(Vertx vertx, Consumer<K, V> consumer) {
-    return new KafkaReadStreamImpl<>(vertx, consumer, new KafkaClientOptions());
+    return create(vertx, consumer, new KafkaClientOptions());
+  }
+
+  /**
+   * Create a new KafkaReadStream instance
+   *
+   * @param vertx    Vert.x instance to use
+   * @param consumer native Kafka consumer instance
+   * @param options  options used only for tracing settings
+   * @return an instance of the KafkaReadStream
+   */
+  static <K, V> KafkaReadStream<K, V> create(Vertx vertx, Consumer<K, V> consumer, KafkaClientOptions options) {
+    return new KafkaReadStreamImpl<>(vertx, consumer, options);
   }
 
   /**

--- a/src/main/java/io/vertx/kafka/client/producer/KafkaProducer.java
+++ b/src/main/java/io/vertx/kafka/client/producer/KafkaProducer.java
@@ -34,6 +34,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE;
+
 /**
  * Vert.x Kafka producer.
  * <p>
@@ -201,9 +203,22 @@ public interface KafkaProducer<K, V> extends WriteStream<KafkaProducerRecord<K, 
    * @param producer the Kafka producer to wrap
    * @return  an instance of the KafkaProducer
    */
-  @GenIgnore
+  @GenIgnore(PERMITTED_TYPE)
   static <K, V> KafkaProducer<K, V> create(Vertx vertx, Producer<K, V> producer) {
-    KafkaWriteStream<K, V> stream = KafkaWriteStream.create(vertx, producer);
+    return create(vertx, producer, new KafkaClientOptions());
+  }
+
+  /**
+   * Create a new KafkaProducer instance from a native {@link Producer}.
+   *
+   * @param vertx    Vert.x instance to use
+   * @param producer the Kafka producer to wrap
+   * @param options  options used only for tracing settings
+   * @return an instance of the KafkaProducer
+   */
+  @GenIgnore(PERMITTED_TYPE)
+  static <K, V> KafkaProducer<K, V> create(Vertx vertx, Producer<K, V> producer, KafkaClientOptions options) {
+    KafkaWriteStream<K, V> stream = KafkaWriteStream.create(vertx, producer, options);
     return new KafkaProducerImpl<>(vertx, stream);
   }
 

--- a/src/main/java/io/vertx/kafka/client/producer/KafkaWriteStream.java
+++ b/src/main/java/io/vertx/kafka/client/producer/KafkaWriteStream.java
@@ -193,7 +193,18 @@ public interface KafkaWriteStream<K, V> extends WriteStream<ProducerRecord<K, V>
    * @param producer  native Kafka producer instance
    */
   static <K, V> KafkaWriteStream<K, V> create(Vertx vertx, Producer<K, V> producer) {
-    return new KafkaWriteStreamImpl<>(vertx, producer, new KafkaClientOptions());
+    return create(vertx, producer, new KafkaClientOptions());
+  }
+
+  /**
+   * Create a new KafkaWriteStream instance.
+   *
+   * @param vertx    Vert.x instance to use
+   * @param producer native Kafka producer instance
+   * @param options  options used only for tracing settings
+   */
+  static <K, V> KafkaWriteStream<K, V> create(Vertx vertx, Producer<K, V> producer, KafkaClientOptions options) {
+    return new KafkaWriteStreamImpl<>(vertx, producer, options);
   }
 
   @Fluent


### PR DESCRIPTION
When creating a producer/consumer (or the stream equivalent) from an existing Kafka client producer/consumer, default tracing options where used.

Consequently, the policy was always set to PROPAGATE.

Besides, when creating a shared producer, user provided config was used to create the Kafka producer, but then default options were used for tracing.