### PR TITLE
4.x Backport - Fix issue with batchHandler not being called without also using handler

### DIFF
--- a/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ConsumerTestBase.java
@@ -1337,7 +1337,6 @@ public abstract class ConsumerTestBase extends KafkaClusterTestBase {
       }
       batchHandler.complete();
     });
-    wrappedConsumer.handler(rec -> {});
     wrappedConsumer.subscribe(Collections.singleton(topicName));
   }
 


### PR DESCRIPTION
Backporting #250 to the 4.x branch.