### PR TITLE
Upgrade kafka-clients from 3.5.0 to 3.7.0 fixing snappy vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
 
   <properties>
     <stack.version>5.0.0-SNAPSHOT</stack.version>
-    <kafka.version>3.5.0</kafka.version>
-    <debezium.version>2.1.4.Final</debezium.version>
+    <kafka.version>3.7.0</kafka.version>
+    <debezium.version>2.6.1.Final</debezium.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
 


### PR DESCRIPTION
The kafka-clients upgrade indirectly upgrades snappy-java from 1.1.10.0 to 1.1.10.5 fixing these snappy-java vulnerablities:

* https://nvd.nist.gov/vuln/detail/CVE-2023-34453
* https://nvd.nist.gov/vuln/detail/CVE-2023-34454
* https://nvd.nist.gov/vuln/detail/CVE-2023-34455
* https://nvd.nist.gov/vuln/detail/CVE-2023-43642

kafka-clients 3.7.0 requires to bump the test dependency debezium from 2.1.4.Final to 2.6.1.Final.