### PR TITLE
Upgrade Kafka 3.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
 
   <properties>
     <stack.version>4.5.8-SNAPSHOT</stack.version>
-    <kafka.version>3.5.0</kafka.version>
-    <debezium.version>1.8.0.Final</debezium.version>
+    <kafka.version>3.7.0</kafka.version>
+    <debezium.version>2.6.1.Final</debezium.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
 


### PR DESCRIPTION
Cherry picking https://github.com/vert-x3/vertx-kafka-client/pull/265 to update Kafka and Debezium on 4.x