### PR TITLE
Upgrade kafka-clients from 3.5.0 to 3.7.0 fixing snappy vulnerabilities

### DIFF
--- a/.github/workflows/ci-4.x.yml
+++ b/.github/workflows/ci-4.x.yml
@@ -20,11 +20,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.jdk }}
+          java-version: |
+            ${{ matrix.jdk }}
+            17
           distribution: temurin
       - name: Run tests
         run: mvn -s .github/maven-ci-settings.xml -q clean verify -B

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,8 @@
     <kafka.version>3.7.0</kafka.version>
     <debezium.version>2.6.1.Final</debezium.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
+    <maven.compiler.testSource>17</maven.compiler.testSource>
+    <maven.compiler.testTarget>17</maven.compiler.testTarget>
   </properties>
 
   <dependencyManagement>
@@ -109,6 +111,27 @@
   </dependencies>
 
   <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-toolchains-plugin</artifactId>
+        <version>1.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>toolchain</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <toolchains>
+            <jdk>
+              <version>17</version>
+            </jdk>
+          </toolchains>
+        </configuration>
+      </plugin>
+    </plugins>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
 
   <properties>
     <stack.version>4.5.8-SNAPSHOT</stack.version>
-    <kafka.version>3.5.0</kafka.version>
-    <debezium.version>1.8.0.Final</debezium.version>
+    <kafka.version>3.7.0</kafka.version>
+    <debezium.version>2.6.1.Final</debezium.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
 


### PR DESCRIPTION
The kafka-clients upgrade indirectly upgrades snappy-java from 1.1.10.0 to 1.1.10.5 fixing these snappy-java vulnerablities:

* https://nvd.nist.gov/vuln/detail/CVE-2023-34453
* https://nvd.nist.gov/vuln/detail/CVE-2023-34454
* https://nvd.nist.gov/vuln/detail/CVE-2023-34455
* https://nvd.nist.gov/vuln/detail/CVE-2023-43642

kafka-clients 3.7.0 requires to bump the test dependency debezium from 2.1.4.Final to 2.6.1.Final.
