### PR TITLE
Upgrade kafka-clients from 3.7.1 to 3.7.2 fixing CVE-2024-56128

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
   </scm>
 
   <properties>
-    <kafka.version>3.7.1</kafka.version>
+    <kafka.version>3.7.2</kafka.version>
     <debezium.version>2.7.3.Final</debezium.version>
   </properties>
 


### PR DESCRIPTION
https://github.com/advisories/GHSA-p7c9-8xx8-h74f

Motivation:

Fix incorrect SCRAM authentication.

Fixes #288