### PR TITLE
Upgrade kafka-clients from 3.7.1 to 3.9.1 fixing CVE-2025-27817 (4.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
   <properties>
     <kafka.version>3.9.1</kafka.version>
-    <strimzi.testcontainer.version>0.109.1</strimzi.testcontainer.version>
+    <strimzi.testcontainer.version>0.111.0</strimzi.testcontainer.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
     <maven.compiler.testSource>17</maven.compiler.testSource>
     <maven.compiler.testTarget>17</maven.compiler.testTarget>


### PR DESCRIPTION
Motivation:

Upgrade Kafka to fix https://github.com/advisories/GHSA-vgq5-3255-v292 (SSRF vulnerability)

Original master PR: https://github.com/vert-x3/vertx-kafka-client/pull/293