### PR TITLE
Upgrade kafka-clients from 3.7.1 to 3.9.1 fixing CVE-2025-27817 (5.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
   </scm>
 
   <properties>
-    <kafka.version>3.7.1</kafka.version>
+    <kafka.version>3.9.1</kafka.version>
     <strimzi.testcontainer.version>0.109.1</strimzi.testcontainer.version>
   </properties>
 


### PR DESCRIPTION
Motivation:

Upgrade Kafka to fix https://github.com/advisories/GHSA-vgq5-3255-v292 (SSRF vulnerability)

Original master PR: https://github.com/vert-x3/vertx-kafka-client/pull/293
4.x PR: https://github.com/vert-x3/vertx-kafka-client/pull/296