### PR TITLE
Upgrade to Kafka Client 3.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,13 @@
   </scm>
 
   <properties>
-    <kafka.version>3.9.1</kafka.version>
+    <kafka.version>3.9.2</kafka.version>
     <strimzi.testcontainer.version>0.111.0</strimzi.testcontainer.version>
+    <!-- 3.9.2 is not compatible with Strimzi testcontainer 0.111.0  -->
+    <!-- But 0.111.0 is the latest version that supports Kafka 3.9 -->
+    <!-- So we use the latest 3.9 version of the Kafka client as a dependency -->
+    <!-- But we must use a previous version of Kafka in the Strimzi testcontainer config -->
+    <test.kafka.version>3.9.1</test.kafka.version>
   </properties>
 
   <dependencyManagement>
@@ -164,7 +169,7 @@
           <configuration>
             <argLine>-server -Xmx1200M</argLine>
             <systemPropertyVariables>
-              <kafka.version>${kafka.version}</kafka.version>
+              <test.kafka.version>${test.kafka.version}</test.kafka.version>
             </systemPropertyVariables>
           </configuration>
         </plugin>

--- a/src/test/java/io/vertx/kafka/client/tests/KafkaStrimziTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/KafkaStrimziTestBase.java
@@ -35,7 +35,7 @@ public abstract class KafkaStrimziTestBase extends KafkaTestBase {
 
   private static final Map<String, KafkaConsumer<?, ?>> activeConsumers = new ConcurrentHashMap<>();
   protected static boolean ACL = false;
-  private static final String KAFKA_VERSION = System.getProperty("kafka.version");
+  private static final String KAFKA_VERSION = System.getProperty("test.kafka.version");
 
   public static KafkaClusterWrapper kafkaCluster(boolean acl, int brokers) {
     if (kafkaCluster != null) {


### PR DESCRIPTION
See #294

3.9.1 brings transitively a vulnerable version of `org.lz4` (see https://github.com/advisories/GHSA-vqf4-7m7x-wgfc)

In this commit, we introduce a `test.kafka.version` property that allows to have a slightly different version of Kafka for the Strimzi testcontainer and the Kafka client JAR dependency.

Indeed, Strimzi testcontainer 0.111.0 is the latest version that support Kafka 3.9 but it doesn't support Kafka 3.9.2.