### PR TITLE
Change scope of the test container dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,11 +112,13 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
       <version>1.21.4</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>toxiproxy</artifactId>
       <version>1.21.4</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
These dependencies are only needed during tests and bloat the runtime unnecessarily 

This was introduced recently via https://github.com/vert-x3/vertx-kafka-client/commit/089b8dbc29e2699fd6887897c7bae0b50b79f01e

Backport of #316


