### PR TITLE
Fixes broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,9 @@ As producer, its API provides methods for sending message to a topic partition l
 
 See the online docs for more details:
 - [Java](https://vertx.io/docs/vertx-kafka-client/java)
-- [JavaScript](https://vertx.io/docs/vertx-kafka-client/js)
-- [Ruby](https://vertx.io/docs/vertx-kafka-client/ruby)
-- [Groovy](https://vertx.io/docs/vertx-kafka-client/groovy)
-- [Kotlin](https://vertx.io/docs/vertx-kafka-client/kotlin)
 
 Important aspects of Topic Management, such as creating a topic, deleting a topic, changing configuration of a topic, are also supported.
 See the online docs for more details:
-- [Java](https://vertx.io/docs/vertx-kafka-client/java/#_vert_x_kafka_adminutils)
-- [JavaScript](https://vertx.io/docs/vertx-kafka-client/js/#_vert_x_kafka_adminutils)
-- [Ruby](https://vertx.io/docs/vertx-kafka-client/ruby/#_vert_x_kafka_adminutils)
-- [Groovy](https://vertx.io/docs/vertx-kafka-client/groovy/#_vert_x_kafka_adminutils)
-- [Kotlin](https://vertx.io/docs/vertx-kafka-client/kotlin/#_vert_x_kafka_adminutils)
+- [Topic Management](https://vertx.io/docs/vertx-kafka-client/java/#_vert_x_kafka_admin_client)
 
 **Note: This module has Tech Preview status, this means the API can change between versions.**


### PR DESCRIPTION
Motivation:

Fixes broken links in README.md. This PR addresses issues in https://github.com/vert-x3/vertx-kafka-client/issues/135


