### PR TITLE
Add KafkaShareConsumer for KIP-932 share groups

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,0 +1,102 @@
+# For local development and manual testing
+services:
+
+  kafka-1:
+    image: apache/kafka:4.2.0
+    container_name: kafka-1
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-1:9093,2@kafka-2:9093
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:29092,EXTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-1:29092,EXTERNAL://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+
+      # Share group (KIP-932)
+      KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS: classic,consumer,streams,share
+      KAFKA_GROUP_SHARE_AUTO_OFFSET_RESET: earliest
+      KAFKA_GROUP_SHARE_MIN_HEARTBEAT_INTERVAL_MS: "500"
+      KAFKA_GROUP_SHARE_HEARTBEAT_INTERVAL_MS: "1000"
+      KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR: "1"
+      KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR: "1"
+      KAFKA_SHARE_COORDINATOR_STATE_TOPIC_NUM_PARTITIONS: "1"
+
+      # Tuning for local dev
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: "1"
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    healthcheck:
+      test: [ "CMD-SHELL", "nc -z localhost 9092 || exit 1" ]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 15s
+    networks:
+      - kafka-net
+
+  kafka-2:
+    image: apache/kafka:4.2.0
+    container_name: kafka-2
+    ports:
+      - "9094:9094"
+    environment:
+      KAFKA_NODE_ID: 2
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-1:9093,2@kafka-2:9093
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:29094,EXTERNAL://0.0.0.0:9094,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-2:29094,EXTERNAL://localhost:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+
+      # Share group (KIP-932)
+      KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS: classic,consumer,streams,share
+      KAFKA_GROUP_SHARE_AUTO_OFFSET_RESET: earliest
+      KAFKA_GROUP_SHARE_MIN_HEARTBEAT_INTERVAL_MS: "500"
+      KAFKA_GROUP_SHARE_HEARTBEAT_INTERVAL_MS: "1000"
+      KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR: "1"
+      KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR: "1"
+      KAFKA_SHARE_COORDINATOR_STATE_TOPIC_NUM_PARTITIONS: "1"
+
+      # Tuning for local dev
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "1"
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: "1"
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    healthcheck:
+      test: [ "CMD-SHELL", "nc -z localhost 9094 || exit 1" ]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 15s
+    networks:
+      - kafka-net
+
+  kafka-ui:
+    image: ghcr.io/kafbat/kafka-ui:latest
+    container_name: kafbat-ui
+    ports:
+      - "8080:8080"
+    depends_on:
+      kafka-1:
+        condition: service_healthy
+      kafka-2:
+        condition: service_healthy
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local-share-dev
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka-1:29092,kafka-2:29094
+    networks:
+      - kafka-net
+
+networks:
+  kafka-net:
+    driver: bridge

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaShareConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaShareConsumer.java
@@ -1,0 +1,388 @@
+package io.vertx.kafka.client.consumer;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.kafka.client.common.KafkaClientOptions;
+import io.vertx.kafka.client.consumer.impl.KafkaShareConsumerImpl;
+import io.vertx.kafka.client.consumer.impl.KafkaShareReadStreamImpl;
+import io.vertx.kafka.client.serialization.VertxSerdes;
+import org.apache.kafka.clients.consumer.AcknowledgeType;
+import org.apache.kafka.clients.consumer.AcknowledgementCommitCallback;
+import org.apache.kafka.clients.consumer.ShareConsumer;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.time.Duration;
+import java.util.*;
+
+import static io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE;
+
+@VertxGen
+public interface KafkaShareConsumer<K, V> extends ReadStream<KafkaShareConsumerRecord<K, V>> {
+
+  /**
+   * Create a new {@code KafkaShareConsumer} wrapping a native Kafka {@link ShareConsumer}.
+   *
+   * @param vertx         the Vert.x instance
+   * @param shareConsumer the native Kafka share consumer to wrap
+   * @return a new {@code KafkaShareConsumer}
+   */
+  @GenIgnore(PERMITTED_TYPE)
+  static <K, V> KafkaShareConsumer<K, V> create(Vertx vertx, ShareConsumer<K, V> shareConsumer) {
+    KafkaShareReadStreamImpl<K, V> stream = new KafkaShareReadStreamImpl<>(vertx, shareConsumer, new KafkaClientOptions());
+    return new KafkaShareConsumerImpl<>(stream).registerCloseHook();
+  }
+
+  /**
+   * Create a new {@code KafkaShareConsumer} from a {@link Map} configuration.
+   *
+   * @param vertx  the Vert.x instance
+   * @param config Kafka consumer configuration
+   * @return a new {@code KafkaShareConsumer}
+   */
+  static <K, V> KafkaShareConsumer<K, V> create(Vertx vertx, Map<String, String> config) {
+    KafkaShareReadStreamImpl<K, V> stream = new KafkaShareReadStreamImpl<>(vertx, new org.apache.kafka.clients.consumer.KafkaShareConsumer<>(new HashMap<>(config)), new KafkaClientOptions());
+    return new KafkaShareConsumerImpl<>(stream).registerCloseHook();
+  }
+
+  /**
+   * Create a new {@code KafkaShareConsumer} from a {@link Map} configuration with explicit deserializer types.
+   *
+   * @param vertx     the Vert.x instance
+   * @param config    Kafka consumer configuration
+   * @param keyType   class type for the key deserialization
+   * @param valueType class type for the value deserialization
+   * @return a new {@code KafkaShareConsumer}
+   */
+  static <K, V> KafkaShareConsumer<K, V> create(Vertx vertx, Map<String, String> config,
+                                                Class<K> keyType, Class<V> valueType) {
+    Deserializer<K> keyDeserializer = VertxSerdes.serdeFrom(keyType).deserializer();
+    Deserializer<V> valueDeserializer = VertxSerdes.serdeFrom(valueType).deserializer();
+    return create(vertx, config, keyDeserializer, valueDeserializer);
+  }
+
+  /**
+   * Create a new {@code KafkaShareConsumer} from a {@link Map} configuration with explicit deserializers.
+   *
+   * @param vertx             the Vert.x instance
+   * @param config            Kafka consumer configuration
+   * @param keyDeserializer   key deserializer
+   * @param valueDeserializer value deserializer
+   * @return a new {@code KafkaShareConsumer}
+   */
+  @GenIgnore
+  static <K, V> KafkaShareConsumer<K, V> create(Vertx vertx, Map<String, String> config,
+                                                Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer) {
+    KafkaShareReadStreamImpl<K, V> stream = new KafkaShareReadStreamImpl<>(vertx,
+      new org.apache.kafka.clients.consumer.KafkaShareConsumer<>(new HashMap<>(config), keyDeserializer, valueDeserializer), new KafkaClientOptions());
+    return new KafkaShareConsumerImpl<>(stream).registerCloseHook();
+  }
+
+  /**
+   * Create a new {@code KafkaShareConsumer} from {@link KafkaClientOptions}.
+   *
+   * @param vertx   the Vert.x instance
+   * @param options Kafka client options
+   * @return a new {@code KafkaShareConsumer}
+   */
+  static <K, V> KafkaShareConsumer<K, V> create(Vertx vertx, KafkaClientOptions options) {
+    Map<String, Object> config = new HashMap<>();
+    if (options.getConfig() != null) config.putAll(options.getConfig());
+    KafkaShareReadStreamImpl<K, V> stream = new KafkaShareReadStreamImpl<>(vertx, new org.apache.kafka.clients.consumer.KafkaShareConsumer<>(config), options);
+    return new KafkaShareConsumerImpl<>(stream).registerCloseHook();
+  }
+
+  /**
+   * Create a new {@code KafkaShareConsumer} from {@link KafkaClientOptions} with explicit deserializer types.
+   *
+   * @param vertx     the Vert.x instance
+   * @param options   Kafka client options
+   * @param keyType   class type for the key deserialization
+   * @param valueType class type for the value deserialization
+   * @return a new {@code KafkaShareConsumer}
+   */
+  static <K, V> KafkaShareConsumer<K, V> create(Vertx vertx, KafkaClientOptions options,
+                                                Class<K> keyType, Class<V> valueType) {
+    Deserializer<K> keyDeserializer = VertxSerdes.serdeFrom(keyType).deserializer();
+    Deserializer<V> valueDeserializer = VertxSerdes.serdeFrom(valueType).deserializer();
+    return create(vertx, options, keyDeserializer, valueDeserializer);
+  }
+
+  /**
+   * Create a new {@code KafkaShareConsumer} from {@link KafkaClientOptions} with explicit deserializers.
+   *
+   * @param vertx             the Vert.x instance
+   * @param options           Kafka client options
+   * @param keyDeserializer   key deserializer
+   * @param valueDeserializer value deserializer
+   * @return a new {@code KafkaShareConsumer}
+   */
+  @GenIgnore
+  static <K, V> KafkaShareConsumer<K, V> create(Vertx vertx, KafkaClientOptions options,
+                                                Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer) {
+    Map<String, Object> config = new HashMap<>();
+    if (options.getConfig() != null) config.putAll(options.getConfig());
+    KafkaShareReadStreamImpl<K, V> stream = new KafkaShareReadStreamImpl<>(vertx,
+      new org.apache.kafka.clients.consumer.KafkaShareConsumer<>(config, keyDeserializer, valueDeserializer), options);
+    return new KafkaShareConsumerImpl<>(stream).registerCloseHook();
+  }
+
+  /**
+   * Create a new {@code KafkaShareConsumer} from a {@link Properties} configuration.
+   *
+   * @param vertx  the Vert.x instance
+   * @param config Kafka consumer configuration
+   * @return a new {@code KafkaShareConsumer}
+   */
+  @GenIgnore
+  static <K, V> KafkaShareConsumer<K, V> create(Vertx vertx, Properties config) {
+    KafkaShareReadStreamImpl<K, V> stream = new KafkaShareReadStreamImpl<>(vertx, new org.apache.kafka.clients.consumer.KafkaShareConsumer<>(config), new KafkaClientOptions());
+    return new KafkaShareConsumerImpl<>(stream).registerCloseHook();
+  }
+
+  /**
+   * Create a new {@code KafkaShareConsumer} from a {@link Properties} configuration with explicit deserializer types.
+   *
+   * @param vertx     the Vert.x instance
+   * @param config    Kafka consumer configuration
+   * @param keyType   class type for the key deserialization
+   * @param valueType class type for the value deserialization
+   * @return a new {@code KafkaShareConsumer}
+   */
+  @GenIgnore
+  static <K, V> KafkaShareConsumer<K, V> create(Vertx vertx, Properties config,
+                                                Class<K> keyType, Class<V> valueType) {
+    Deserializer<K> keyDeserializer = VertxSerdes.serdeFrom(keyType).deserializer();
+    Deserializer<V> valueDeserializer = VertxSerdes.serdeFrom(valueType).deserializer();
+    return create(vertx, config, keyDeserializer, valueDeserializer);
+  }
+
+  /**
+   * Create a new {@code KafkaShareConsumer} from a {@link Properties} configuration with explicit deserializers.
+   *
+   * @param vertx             the Vert.x instance
+   * @param config            Kafka consumer configuration
+   * @param keyDeserializer   key deserializer
+   * @param valueDeserializer value deserializer
+   * @return a new {@code KafkaShareConsumer}
+   */
+  @GenIgnore
+  static <K, V> KafkaShareConsumer<K, V> create(Vertx vertx, Properties config,
+                                                Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer) {
+    KafkaShareReadStreamImpl<K, V> stream = new KafkaShareReadStreamImpl<>(vertx,
+      new org.apache.kafka.clients.consumer.KafkaShareConsumer<>(config, keyDeserializer, valueDeserializer), new KafkaClientOptions());
+    return new KafkaShareConsumerImpl<>(stream).registerCloseHook();
+  }
+
+  @Fluent
+  @Override
+  KafkaShareConsumer<K, V> exceptionHandler(Handler<Throwable> handler);
+
+  @Fluent
+  @Override
+  KafkaShareConsumer<K, V> handler(Handler<KafkaShareConsumerRecord<K, V>> handler);
+
+  /**
+   * Set a handler to receive records in batches rather than one at a time.
+   * <p>
+   * When set, this takes precedence over the per-record {@link #handler}. The entire
+   * batch returned by a single poll is delivered as a {@link KafkaShareConsumerRecords}
+   * to this handler. Useful when processing efficiency matters more than per-record flow control.
+   *
+   * @param handler the batch handler
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  KafkaShareConsumer<K, V> batchHandler(Handler<KafkaShareConsumerRecords<K, V>> handler);
+
+  /**
+   * Close the consumer, releasing all resources.
+   *
+   * @return a future completed when the consumer is closed
+   */
+  Future<Void> close();
+
+  /**
+   * Subscribe to a single topic. The consumer will start receiving records via the
+   * {@link #handler} once subscription is established.
+   *
+   * @param topic the topic to subscribe to
+   * @return a future completed when the subscription is established
+   */
+  Future<Void> subscribe(String topic);
+
+  /**
+   * Subscribe to a set of topics. The consumer will start receiving records via the
+   * {@link #handler} once subscription is established.
+   *
+   * @param topics the topics to subscribe to
+   * @return a future completed when the subscription is established
+   */
+  Future<Void> subscribe(Set<String> topics);
+
+  /**
+   * @return a future completed with the set of topics this consumer is currently subscribed to
+   */
+  Future<Set<String>> subscription();
+
+  /**
+   * Unsubscribe from all topics.
+   *
+   * @return a future completed when the consumer has unsubscribed
+   */
+  Future<Void> unsubscribe();
+
+  /**
+   * Manually poll a batch of records from the broker, waiting up to {@code timeout} for records
+   * to become available.
+   * <p>
+   * Use this method when you want explicit control over when polling occurs. When using
+   * the streaming API ({@link #handler}), polling is managed internally and this method
+   * should not be called concurrently.
+   *
+   * @param timeout the maximum time to wait for records
+   * @return a future completed with the polled records
+   */
+  @GenIgnore(PERMITTED_TYPE)
+  Future<KafkaShareConsumerRecords<K, V>> poll(Duration timeout);
+
+  /**
+   * Commit the acknowledgements for the records returned by the last poll asynchronously.
+   * <p>
+   * This is a fire-and-forget operation. To be notified of the commit result,
+   * register a callback with {@link #setAcknowledgementCommitCallback}.
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  KafkaShareConsumer<K, V> commitAsync();
+
+  /**
+   * Set a callback to be notified of the result of {@link #commitAsync} operations.
+   * <p>
+   * The callback receives a map of per-partition results and an overall exception
+   * (which is {@code null} on success). The callback is always invoked on the Vert.x
+   * event loop.
+   *
+   * @param callback the callback to invoke after each async commit
+   * @return a reference to this, so the API can be used fluently
+   */
+  @GenIgnore
+  KafkaShareConsumer<K, V> setAcknowledgementCommitCallback(AcknowledgementCommitCallback callback);
+
+  /**
+   * Acknowledge delivery of a record returned by the last {@link #poll} call.
+   * <p>
+   * The {@link AcknowledgeType} indicates how the record was processed:
+   * <ul>
+   *   <li>{@link AcknowledgeType#ACCEPT} — record was processed successfully,
+   *       it will not be redelivered</li>
+   *   <li>{@link AcknowledgeType#RELEASE} — record was not processed, it will
+   *       be made available for redelivery to another consumer</li>
+   *   <li>{@link AcknowledgeType#REJECT} — record is unprocessable, it will
+   *       not be redelivered to any consumer</li>
+   *   <li>{@link AcknowledgeType#RENEW} — record is still being processed,
+   *       the acquisition lock will be extended and the record will be
+   *       returned again on the next {@link #poll} call</li>
+   * </ul>
+   * <p>
+   * This method only updates a local in-memory state. The acknowledgement
+   * is sent to the broker on the next {@link #commitSync()},
+   * {@link #commitAsync()} or {@link #poll} call.
+   * <p>
+   * This method can only be used if the consumer is configured with
+   * <b>explicit acknowledgement</b> ({@code share.acknowledgement.mode=explicit}).
+   *
+   * @param record the record to acknowledge
+   * @param type   the acknowledgement type indicating how the record was processed
+   * @return a future completed when the local acknowledgement state is updated
+   */
+  Future<Void> acknowledge(KafkaShareConsumerRecord<K, V> record, AcknowledgeType type);
+
+  /**
+   * Commit the acknowledgements for the records returned by the last {@link #poll} call.
+   * <p>
+   * If the consumer is using <b>explicit acknowledgement</b>, only the records acknowledged
+   * using {@link #acknowledge} will be committed. If the consumer is using
+   * <b>implicit acknowledgement</b>, all records returned by the last poll are committed.
+   * <p>
+   * This is a synchronous commit that blocks until either the commit succeeds or fails.
+   * The timeout is controlled by the {@code default.api.timeout.ms} configuration property.
+   * <p>
+   * If a single partition fails, the future fails with the original exception.
+   * If multiple partitions fail, the future fails with a summary exception listing
+   * each failed partition and its error on a separate line.
+   * <p>
+   * For full per-partition result control use {@link #commitSync(Duration)}.
+   *
+   * @return a future completed when all acknowledgements are committed successfully,
+   * or failed if one or more partitions could not be committed
+   */
+  Future<Void> commitSync();
+
+  /**
+   * Commit the acknowledgements for the records returned by the last {@link #poll} call,
+   * waiting up to the specified timeout for the operation to complete.
+   * <p>
+   * If the consumer is using <b>explicit acknowledgement</b>, only the records acknowledged
+   * using {@link #acknowledge} will be committed. If the consumer is using
+   * <b>implicit acknowledgement</b>, all records returned by the last poll are committed.
+   * <p>
+   * Unlike {@link #commitSync()}, this method returns the full per-partition result map,
+   * allowing the caller to inspect which partitions succeeded and which failed independently.
+   * A partition that failed will have an {@link java.util.Optional} containing the exception,
+   * a partition that succeeded will have an empty {@link java.util.Optional}.
+   * <p>
+   * Example usage:
+   * <pre>
+   *   consumer.commitSync(Duration.ofSeconds(5)).onComplete(ar -> {
+   *     if (ar.succeeded()) {
+   *       ar.result().forEach((partition, error) -> {
+   *         if (error.isPresent()) {
+   *           log.error("Partition {} failed: {}", partition, error.get().getMessage());
+   *         }
+   *       });
+   *     }
+   *   });
+   * </pre>
+   *
+   * @param timeout the maximum time to wait for the commit to complete,
+   *                if {@code null} the broker default ({@code default.api.timeout.ms})
+   *                will be used
+   * @return a future completed with a map of per-partition results
+   */
+  @GenIgnore
+  Future<Map<TopicIdPartition, Optional<KafkaException>>> commitSync(Duration timeout);
+
+  /**
+   * Set the timeout used for internal polling in streaming mode.
+   * <p>
+   * This controls how long the internal poll loop blocks waiting for records from
+   * the broker on each iteration. A shorter timeout makes the consumer more responsive
+   * to close and pause requests; a longer timeout reduces CPU overhead when topics
+   * are sparse. Defaults to 1 second.
+   *
+   * @param timeout the poll timeout
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  @GenIgnore(PERMITTED_TYPE)
+  KafkaShareConsumer<K, V> pollTimeout(Duration timeout);
+
+  /**
+   * Return the underlying native Kafka {@link ShareConsumer}.
+   * <p>
+   * Use with care — direct calls on the native consumer bypass the Vert.x threading
+   * model and may conflict with the internal poll loop.
+   *
+   * @return the native Kafka share consumer
+   */
+  @GenIgnore(PERMITTED_TYPE)
+  ShareConsumer<K, V> unwrap();
+}

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaShareConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaShareConsumer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
 package io.vertx.kafka.client.consumer;
 
 import io.vertx.codegen.annotations.Fluent;

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaShareConsumer.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaShareConsumer.java
@@ -14,6 +14,8 @@ import io.vertx.kafka.client.serialization.VertxSerdes;
 import org.apache.kafka.clients.consumer.AcknowledgeType;
 import org.apache.kafka.clients.consumer.AcknowledgementCommitCallback;
 import org.apache.kafka.clients.consumer.ShareConsumer;
+
+import java.util.concurrent.ThreadFactory;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -95,6 +97,32 @@ public interface KafkaShareConsumer<K, V> extends ReadStream<KafkaShareConsumerR
     Map<String, Object> config = new HashMap<>();
     if (options.getConfig() != null) config.putAll(options.getConfig());
     KafkaShareReadStreamImpl<K, V> stream = new KafkaShareReadStreamImpl<>(vertx, new org.apache.kafka.clients.consumer.KafkaShareConsumer<>(config), options);
+    return new KafkaShareConsumerImpl<>(stream).registerCloseHook();
+  }
+
+  /**
+   * Create a new {@code KafkaShareConsumer} from {@link KafkaClientOptions} with a custom
+   * {@link ThreadFactory} for the internal worker thread.
+   * <p>
+   * <b>Experimental</b>: use this method to control the threading model of the internal poll
+   * worker. For example, on Java 21+ you can pass a virtual thread factory:
+   * <pre>
+   *   KafkaShareConsumer.create(vertx, options,
+   *     Thread.ofVirtual().name("kafka-share-worker-", 0).factory());
+   * </pre>
+   * When {@code null} is passed the default platform thread factory is used.
+   *
+   * @param vertx         the Vert.x instance
+   * @param options       Kafka client options
+   * @param threadFactory factory used to create the internal worker thread, or {@code null} for the default
+   * @return a new {@code KafkaShareConsumer}
+   */
+  @GenIgnore
+  static <K, V> KafkaShareConsumer<K, V> create(Vertx vertx, KafkaClientOptions options, ThreadFactory threadFactory) {
+    Map<String, Object> config = new HashMap<>();
+    if (options.getConfig() != null) config.putAll(options.getConfig());
+    KafkaShareReadStreamImpl<K, V> stream = new KafkaShareReadStreamImpl<>(vertx,
+      new org.apache.kafka.clients.consumer.KafkaShareConsumer<>(config), options, threadFactory);
     return new KafkaShareConsumerImpl<>(stream).registerCloseHook();
   }
 

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaShareConsumerRecord.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaShareConsumerRecord.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
 package io.vertx.kafka.client.consumer;
 
 import io.vertx.codegen.annotations.VertxGen;

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaShareConsumerRecord.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaShareConsumerRecord.java
@@ -1,0 +1,11 @@
+package io.vertx.kafka.client.consumer;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * Vert.x Kafka share consumer record
+ */
+@VertxGen
+public interface KafkaShareConsumerRecord<K, V> extends KafkaConsumerRecord<K, V> {
+  int deliveryCount();
+}

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaShareConsumerRecords.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaShareConsumerRecords.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
 package io.vertx.kafka.client.consumer;
 
 import io.vertx.codegen.annotations.GenIgnore;

--- a/src/main/java/io/vertx/kafka/client/consumer/KafkaShareConsumerRecords.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/KafkaShareConsumerRecords.java
@@ -1,0 +1,18 @@
+package io.vertx.kafka.client.consumer;
+
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+
+@VertxGen
+public interface KafkaShareConsumerRecords<K, V> {
+
+  int size();
+
+  boolean isEmpty();
+
+  KafkaShareConsumerRecord<K, V> recordAt(int index);
+
+  @GenIgnore
+  ConsumerRecords<K, V> records();
+}

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/AbstractKafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/AbstractKafkaReadStreamImpl.java
@@ -1,0 +1,189 @@
+package io.vertx.kafka.client.consumer.impl;
+
+import io.vertx.core.*;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.kafka.client.common.KafkaClientOptions;
+import io.vertx.kafka.client.common.tracing.ConsumerTracer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Abstract/common worker-thread class used by {@link KafkaShareReadStreamImpl}
+ * and maybe in the future by {@link KafkaReadStreamImpl} for: demand tracking, the schedule/run loop,
+ * and the single-threaded executor lifecycle.
+ * <p>
+ * Subclasses must implement the following method:
+ * <ul>
+ *   <li>{@link #pollRecords(Handler)} — perform a single poll against the broker on the
+ *       worker thread and deliver the result to the provided handler on the event loop</li>
+ * </ul>
+ * Close and wakeup behavior is provided by passing {@code Runnable} references to the
+ * constructor, so subclasses do not need to override anything for lifecycle management.
+ */
+abstract class AbstractKafkaReadStreamImpl<K, V> {
+
+  private static final AtomicInteger threadCount = new AtomicInteger(0);
+
+  protected final Context context;
+  private final Runnable wakeup;
+  private final Runnable closeNative;
+  private final ConsumerTracer tracer;
+
+  protected final AtomicBoolean closed = new AtomicBoolean(true);
+  protected final AtomicBoolean polling = new AtomicBoolean(false);
+  protected final AtomicLong demand = new AtomicLong(Long.MAX_VALUE);
+
+  protected ExecutorService worker;
+  protected Handler<ConsumerRecord<K, V>> recordHandler;
+  protected Handler<ConsumerRecords<K, V>> batchHandler;
+  protected Handler<Throwable> exceptionHandler;
+  protected Handler<Void> endHandler;
+  protected Duration pollTimeout = Duration.ofSeconds(1);
+  private Iterator<ConsumerRecord<K, V>> current;
+
+  protected AbstractKafkaReadStreamImpl(Vertx vertx, Runnable wakeup, Runnable closeNative, KafkaClientOptions options) {
+    ContextInternal ctxInt = ((ContextInternal) vertx.getOrCreateContext()).unwrap();
+    this.context = ctxInt;
+    this.wakeup = wakeup;
+    this.closeNative = closeNative;
+    this.tracer = ConsumerTracer.create(ctxInt.tracer(), options);
+  }
+
+  protected ExecutorService createWorker(String namePrefix) {
+    return Executors.newSingleThreadExecutor(r -> new Thread(r, namePrefix + threadCount.getAndIncrement()));
+  }
+
+  public void exceptionHandler(Handler<Throwable> handler) {
+    this.exceptionHandler = handler;
+  }
+
+  public void handler(Handler<ConsumerRecord<K, V>> handler) {
+    this.recordHandler = handler;
+    schedule();
+  }
+
+  public void batchHandler(Handler<ConsumerRecords<K, V>> handler) {
+    this.batchHandler = handler;
+    schedule();
+  }
+
+  public void endHandler(Handler<Void> handler) {
+    this.endHandler = handler;
+  }
+
+  public void pause() {
+    demand.set(0L);
+  }
+
+  public void resume() {
+    fetch(Long.MAX_VALUE);
+  }
+
+  public void fetch(long amount) {
+    if (amount < 0) {
+      throw new IllegalArgumentException("Invalid claim " + amount);
+    }
+    long updated = demand.updateAndGet(d -> {
+      if (d == Long.MAX_VALUE) return d;
+      long sum = d + amount;
+      return sum < 0L ? Long.MAX_VALUE : sum;
+    });
+    if (updated > 0L) {
+      schedule();
+    }
+  }
+
+  public Future<Void> close() {
+    if (closed.compareAndSet(false, true)) {
+      wakeup.run();
+      Promise<Void> promise = ((ContextInternal) context).promise();
+      worker.submit(() -> {
+        try {
+          closeNative.run();
+          context.runOnContext(v -> {
+            if (endHandler != null) endHandler.handle(null);
+            promise.complete();
+          });
+        } catch (Exception e) {
+          context.runOnContext(v -> promise.fail(e));
+        }
+      });
+      return promise.future().onComplete(v -> worker.shutdownNow());
+    }
+    return ((ContextInternal) context).succeededFuture();
+  }
+
+  protected void schedule() {
+    if (!closed.get() && demand.get() > 0L && (recordHandler != null || batchHandler != null)) {
+      context.runOnContext(v -> run());
+    }
+  }
+
+  private void run() {
+    if (closed.get()) {
+      return;
+    }
+
+    if (current == null || !current.hasNext()) {
+      pollRecords(records -> {
+        if (records != null && records.count() > 0) {
+          if (batchHandler != null) {
+            batchHandler.handle(records);
+            schedule();
+          } else {
+            current = records.iterator();
+            schedule();
+          }
+        } else {
+          context.owner().setTimer(1, t -> schedule());
+        }
+      });
+    } else {
+      int count = 0;
+      out:
+      while (current.hasNext() && count++ < 10) {
+
+        while (true) {
+          long d = demand.get();
+          if (d <= 0L) {
+            break out;
+          } else if (d == Long.MAX_VALUE || demand.compareAndSet(d, d - 1)) {
+            break;
+          }
+        }
+
+        ConsumerRecord<K, V> next = current.next();
+        ContextInternal ctx = ((ContextInternal) context).duplicate();
+        ctx.emit(v -> tracedHandler(ctx, recordHandler).handle(next));
+      }
+      schedule();
+    }
+  }
+
+  private Handler<ConsumerRecord<K, V>> tracedHandler(Context ctx, Handler<ConsumerRecord<K, V>> handler) {
+    return tracer == null ? handler : rec -> {
+      ConsumerTracer.StartedSpan span = tracer.prepareMessageReceived(ctx, rec);
+      try {
+        handler.handle(rec);
+        span.finish(ctx);
+      } catch (Throwable t) {
+        span.fail(ctx, t);
+        throw t;
+      }
+    };
+  }
+
+  /**
+   * Poll a batch of records from the broker on the worker thread and deliver
+   * the result by calling {@code handler} on the event loop.
+   */
+  protected abstract void pollRecords(Handler<ConsumerRecords<K, V>> handler);
+}

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/AbstractKafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/AbstractKafkaReadStreamImpl.java
@@ -9,8 +9,10 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 
 import java.time.Duration;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -36,6 +38,7 @@ abstract class AbstractKafkaReadStreamImpl<K, V> {
   private final Runnable wakeup;
   private final Runnable closeNative;
   private final ConsumerTracer<?> tracer;
+  private final ThreadFactory threadFactory;
 
   protected final AtomicBoolean closed = new AtomicBoolean(true);
   protected final AtomicBoolean polling = new AtomicBoolean(false);
@@ -50,15 +53,22 @@ abstract class AbstractKafkaReadStreamImpl<K, V> {
   private Iterator<ConsumerRecord<K, V>> current;
 
   protected AbstractKafkaReadStreamImpl(Vertx vertx, Runnable wakeup, Runnable closeNative, KafkaClientOptions options) {
+    this(vertx, wakeup, closeNative, options, null);
+  }
+
+  protected AbstractKafkaReadStreamImpl(Vertx vertx, Runnable wakeup, Runnable closeNative, KafkaClientOptions options, ThreadFactory threadFactory) {
     ContextInternal ctxInt = ((ContextInternal) vertx.getOrCreateContext()).unwrap();
     this.context = ctxInt;
     this.wakeup = wakeup;
     this.closeNative = closeNative;
     this.tracer = ConsumerTracer.create(ctxInt.tracer(), options);
+    this.threadFactory = threadFactory;
   }
 
   protected ExecutorService createWorker(String namePrefix) {
-    return Executors.newSingleThreadExecutor(r -> new Thread(r, namePrefix + threadCount.getAndIncrement()));
+    return Executors.newSingleThreadExecutor(
+      Objects.requireNonNullElseGet(threadFactory, () -> r -> new Thread(r, namePrefix + threadCount.getAndIncrement()))
+    );
   }
 
   public void exceptionHandler(Handler<Throwable> handler) {

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/AbstractKafkaReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/AbstractKafkaReadStreamImpl.java
@@ -35,7 +35,7 @@ abstract class AbstractKafkaReadStreamImpl<K, V> {
   protected final Context context;
   private final Runnable wakeup;
   private final Runnable closeNative;
-  private final ConsumerTracer tracer;
+  private final ConsumerTracer<?> tracer;
 
   protected final AtomicBoolean closed = new AtomicBoolean(true);
   protected final AtomicBoolean polling = new AtomicBoolean(false);
@@ -170,7 +170,7 @@ abstract class AbstractKafkaReadStreamImpl<K, V> {
 
   private Handler<ConsumerRecord<K, V>> tracedHandler(Context ctx, Handler<ConsumerRecord<K, V>> handler) {
     return tracer == null ? handler : rec -> {
-      ConsumerTracer.StartedSpan span = tracer.prepareMessageReceived(ctx, rec);
+      ConsumerTracer<?>.StartedSpan span = tracer.prepareMessageReceived(ctx, rec);
       try {
         handler.handle(rec);
         span.finish(ctx);

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareConsumerImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareConsumerImpl.java
@@ -1,0 +1,163 @@
+package io.vertx.kafka.client.consumer.impl;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.kafka.client.common.impl.CloseHandler;
+import io.vertx.kafka.client.consumer.KafkaShareConsumer;
+import io.vertx.kafka.client.consumer.KafkaShareConsumerRecord;
+import io.vertx.kafka.client.consumer.KafkaShareConsumerRecords;
+import org.apache.kafka.clients.consumer.AcknowledgeType;
+import org.apache.kafka.clients.consumer.AcknowledgementCommitCallback;
+import org.apache.kafka.clients.consumer.ShareConsumer;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicIdPartition;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class KafkaShareConsumerImpl<K, V> implements KafkaShareConsumer<K, V> {
+
+  private final KafkaShareReadStreamImpl<K, V> stream;
+  private final CloseHandler closeHandler;
+
+  public KafkaShareConsumerImpl(KafkaShareReadStreamImpl<K, V> stream) {
+    this.stream = stream;
+    this.closeHandler = new CloseHandler((timeout, ar) -> stream.close().onComplete(ar));
+  }
+
+  public synchronized KafkaShareConsumerImpl<K, V> registerCloseHook() {
+    Context context = Vertx.currentContext();
+    if (context == null) {
+      return this;
+    }
+    closeHandler.registerCloseHook((ContextInternal) context);
+    return this;
+  }
+
+  @Override
+  public KafkaShareConsumer<K, V> exceptionHandler(Handler<Throwable> handler) {
+    stream.exceptionHandler(handler);
+    return this;
+  }
+
+  @Override
+  public KafkaShareConsumer<K, V> handler(Handler<KafkaShareConsumerRecord<K, V>> handler) {
+    if (handler != null) {
+      stream.handler(record -> handler.handle(new KafkaShareConsumerRecordImpl<>(record)));
+    } else {
+      stream.handler(null);
+    }
+    return this;
+  }
+
+  @Override
+  public KafkaShareConsumer<K, V> batchHandler(Handler<KafkaShareConsumerRecords<K, V>> handler) {
+    if (handler != null) {
+      stream.batchHandler(records -> handler.handle(new KafkaShareConsumerRecordsImpl<>(records)));
+    } else {
+      stream.batchHandler(null);
+    }
+    return this;
+  }
+
+  @Override
+  public KafkaShareConsumer<K, V> pause() {
+    stream.pause();
+    return this;
+  }
+
+  @Override
+  public KafkaShareConsumer<K, V> resume() {
+    stream.resume();
+    return this;
+  }
+
+  @Override
+  public KafkaShareConsumer<K, V> fetch(long amount) {
+    stream.fetch(amount);
+    return this;
+  }
+
+  @Override
+  public KafkaShareConsumer<K, V> endHandler(@Nullable Handler<Void> endHandler) {
+    stream.endHandler(endHandler);
+    return this;
+  }
+
+  @Override
+  public Future<Void> close() {
+    Promise<Void> promise = Promise.promise();
+    closeHandler.close(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Void> subscribe(String topic) {
+    return stream.subscribe(Set.of(topic));
+  }
+
+  @Override
+  public Future<Void> subscribe(Set<String> topics) {
+    return stream.subscribe(topics);
+  }
+
+  @Override
+  public Future<Set<String>> subscription() {
+    return stream.subscription();
+  }
+
+  @Override
+  public Future<Void> unsubscribe() {
+    return stream.unsubscribe();
+  }
+
+  @Override
+  public Future<KafkaShareConsumerRecords<K, V>> poll(Duration timeout) {
+    return stream.poll(timeout).map(KafkaShareConsumerRecordsImpl::new);
+  }
+
+  @Override
+  public KafkaShareConsumer<K, V> commitAsync() {
+    stream.commitAsync();
+    return this;
+  }
+
+  @Override
+  public KafkaShareConsumer<K, V> setAcknowledgementCommitCallback(AcknowledgementCommitCallback callback) {
+    stream.setAcknowledgementCommitCallback(callback);
+    return this;
+  }
+
+  @Override
+  public Future<Void> acknowledge(KafkaShareConsumerRecord<K, V> record, AcknowledgeType type) {
+    return stream.acknowledge(record.record(), type);
+  }
+
+  @Override
+  public Future<Void> commitSync() {
+    return stream.commitSync();
+  }
+
+  @Override
+  public Future<Map<TopicIdPartition, Optional<KafkaException>>> commitSync(Duration timeout) {
+    return stream.commitSync(timeout);
+  }
+
+  @Override
+  public KafkaShareConsumer<K, V> pollTimeout(Duration timeout) {
+    stream.setPollTimeout(timeout);
+    return this;
+  }
+
+  @Override
+  public ShareConsumer<K, V> unwrap() {
+    return stream.unwrap();
+  }
+}

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareConsumerImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareConsumerImpl.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
 package io.vertx.kafka.client.consumer.impl;
 
 import io.vertx.codegen.annotations.Nullable;

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareConsumerRecordImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareConsumerRecordImpl.java
@@ -1,0 +1,32 @@
+package io.vertx.kafka.client.consumer.impl;
+
+import io.vertx.kafka.client.consumer.KafkaShareConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+public class KafkaShareConsumerRecordImpl<K, V> extends KafkaConsumerRecordImpl<K, V> implements KafkaShareConsumerRecord<K, V> {
+
+  public KafkaShareConsumerRecordImpl(ConsumerRecord<K, V> record) {
+    super(record);
+  }
+
+  @Override
+  public int deliveryCount() {
+    return record().deliveryCount()
+      .map(Short::intValue)
+      .orElse(0);
+  }
+
+  @Override
+  public String toString() {
+    return "KafkaShareConsumerRecord{" +
+      "topic=" + topic() +
+      ",partition=" + partition() +
+      ",offset=" + offset() +
+      ",timestamp=" + timestamp() +
+      ",key=" + key() +
+      ",value=" + value() +
+      ",headers=" + headers() +
+      ",deliveryCount=" + deliveryCount() +
+      "}";
+  }
+}

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareConsumerRecordImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareConsumerRecordImpl.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
 package io.vertx.kafka.client.consumer.impl;
 
 import io.vertx.kafka.client.consumer.KafkaShareConsumerRecord;

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareConsumerRecordsImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareConsumerRecordsImpl.java
@@ -1,0 +1,43 @@
+package io.vertx.kafka.client.consumer.impl;
+
+import io.vertx.kafka.client.consumer.KafkaShareConsumerRecord;
+import io.vertx.kafka.client.consumer.KafkaShareConsumerRecords;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class KafkaShareConsumerRecordsImpl<K, V> implements KafkaShareConsumerRecords<K, V> {
+
+  private final ConsumerRecords<K, V> records;
+  private final List<KafkaShareConsumerRecord<K, V>> list;
+
+  public KafkaShareConsumerRecordsImpl(ConsumerRecords<K, V> records) {
+    this.records = records;
+    this.list = new ArrayList<>();
+    for (ConsumerRecord<K, V> record : records) {
+      list.add(new KafkaShareConsumerRecordImpl<>(record));
+    }
+  }
+
+  @Override
+  public int size() {
+    return list.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return list.isEmpty();
+  }
+
+  @Override
+  public KafkaShareConsumerRecord<K, V> recordAt(int index) {
+    return list.get(index);
+  }
+
+  @Override
+  public ConsumerRecords<K, V> records() {
+    return records;
+  }
+}

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareConsumerRecordsImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareConsumerRecordsImpl.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
 package io.vertx.kafka.client.consumer.impl;
 
 import io.vertx.kafka.client.consumer.KafkaShareConsumerRecord;

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareReadStreamImpl.java
@@ -4,7 +4,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.internal.ContextInternal;
 import io.vertx.kafka.client.common.KafkaClientOptions;
 import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.common.KafkaException;
@@ -22,6 +21,7 @@ import java.util.stream.Collectors;
 public class KafkaShareReadStreamImpl<K, V> extends AbstractKafkaReadStreamImpl<K, V> {
 
   private final ShareConsumer<K, V> shareConsumer;
+  private AcknowledgementCommitCallback pendingAckCallback;
 
   public KafkaShareReadStreamImpl(Vertx vertx, ShareConsumer<K, V> shareConsumer) {
     this(vertx, shareConsumer, new KafkaClientOptions(), null);
@@ -79,8 +79,11 @@ public class KafkaShareReadStreamImpl<K, V> extends AbstractKafkaReadStreamImpl<
       worker = createWorker("vert.x-kafka-share-consumer-thread-");
     }
 
+    AcknowledgementCommitCallback cb = pendingAckCallback;
+    pendingAckCallback = null;
     worker.submit(() -> {
       try {
+        if (cb != null) shareConsumer.setAcknowledgementCommitCallback(cb);
         shareConsumer.subscribe(topics);
         context.runOnContext(v -> {
           promise.complete();
@@ -198,9 +201,13 @@ public class KafkaShareReadStreamImpl<K, V> extends AbstractKafkaReadStreamImpl<
   }
 
   public void setAcknowledgementCommitCallback(AcknowledgementCommitCallback callback) {
-    shareConsumer.setAcknowledgementCommitCallback(
-      (offsets, exception) -> context.runOnContext(v -> callback.onComplete(offsets, exception))
-    );
+    AcknowledgementCommitCallback wrapped = callback == null ? null :
+      (offsets, exception) -> context.runOnContext(v -> callback.onComplete(offsets, exception));
+    if (worker == null) {
+      pendingAckCallback = wrapped;
+    } else {
+      worker.submit(() -> shareConsumer.setAcknowledgementCommitCallback(wrapped));
+    }
   }
 
   public void setPollTimeout(Duration timeout) {

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareReadStreamImpl.java
@@ -13,6 +13,7 @@ import org.apache.kafka.common.errors.WakeupException;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.ThreadFactory;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -23,11 +24,15 @@ public class KafkaShareReadStreamImpl<K, V> extends AbstractKafkaReadStreamImpl<
   private final ShareConsumer<K, V> shareConsumer;
 
   public KafkaShareReadStreamImpl(Vertx vertx, ShareConsumer<K, V> shareConsumer) {
-    this(vertx, shareConsumer, new KafkaClientOptions());
+    this(vertx, shareConsumer, new KafkaClientOptions(), null);
   }
 
   public KafkaShareReadStreamImpl(Vertx vertx, ShareConsumer<K, V> shareConsumer, KafkaClientOptions options) {
-    super(vertx, shareConsumer::wakeup, shareConsumer::close, options);
+    this(vertx, shareConsumer, options, null);
+  }
+
+  public KafkaShareReadStreamImpl(Vertx vertx, ShareConsumer<K, V> shareConsumer, KafkaClientOptions options, ThreadFactory threadFactory) {
+    super(vertx, shareConsumer::wakeup, shareConsumer::close, options, threadFactory);
     this.shareConsumer = shareConsumer;
   }
 

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareReadStreamImpl.java
@@ -139,14 +139,17 @@ public class KafkaShareReadStreamImpl<K, V> extends AbstractKafkaReadStreamImpl<
     return promise.future();
   }
 
-  /**
-   * Based on Apache Kafka client javadocs, acknowledgment is committed on the next
-   * commitSync(), commitAsync() or poll(Duration) call, so that worker thread
-   * isn't required here.
-   */
   public Future<Void> acknowledge(ConsumerRecord<K, V> record, AcknowledgeType type) {
-    shareConsumer.acknowledge(record, type);
-    return ((ContextInternal) context).succeededFuture();
+    Promise<Void> promise = Promise.promise();
+    worker.submit(() -> {
+      try {
+        shareConsumer.acknowledge(record, type);
+        context.runOnContext(v -> promise.complete());
+      } catch (Exception e) {
+        context.runOnContext(v -> promise.fail(e));
+      }
+    });
+    return promise.future();
   }
 
   public Future<Map<TopicIdPartition, Optional<KafkaException>>> commitSync(Duration timeout) {

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareReadStreamImpl.java
@@ -1,0 +1,202 @@
+package io.vertx.kafka.client.consumer.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.internal.ContextInternal;
+import io.vertx.kafka.client.common.KafkaClientOptions;
+import org.apache.kafka.clients.consumer.*;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.errors.WakeupException;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class KafkaShareReadStreamImpl<K, V> extends AbstractKafkaReadStreamImpl<K, V> {
+
+  private final ShareConsumer<K, V> shareConsumer;
+
+  public KafkaShareReadStreamImpl(Vertx vertx, ShareConsumer<K, V> shareConsumer) {
+    this(vertx, shareConsumer, new KafkaClientOptions());
+  }
+
+  public KafkaShareReadStreamImpl(Vertx vertx, ShareConsumer<K, V> shareConsumer, KafkaClientOptions options) {
+    super(vertx, shareConsumer::wakeup, shareConsumer::close, options);
+    this.shareConsumer = shareConsumer;
+  }
+
+  @Override
+  protected void pollRecords(Handler<ConsumerRecords<K, V>> handler) {
+    if (polling.compareAndSet(false, true)) {
+      worker.submit(() -> {
+        boolean submitted = false;
+        try {
+          if (!closed.get()) {
+            ConsumerRecords<K, V> records = shareConsumer.poll(pollTimeout);
+            if (records != null && records.count() > 0) {
+              submitted = true;
+              context.runOnContext(v -> {
+                polling.set(false);
+                handler.handle(records);
+              });
+            }
+          }
+        } catch (WakeupException ignore) {
+        } catch (Exception e) {
+          if (exceptionHandler != null) {
+            exceptionHandler.handle(e);
+          }
+        } finally {
+          if (!submitted) {
+            context.runOnContext(v -> {
+              polling.set(false);
+              handler.handle(ConsumerRecords.empty());
+            });
+          }
+        }
+      });
+    }
+  }
+
+  public Future<Void> subscribe(Set<String> topics) {
+    Promise<Void> promise = Promise.promise();
+
+    if (closed.compareAndSet(true, false)) {
+      worker = createWorker("vert.x-kafka-share-consumer-thread-");
+    }
+
+    worker.submit(() -> {
+      try {
+        shareConsumer.subscribe(topics);
+        context.runOnContext(v -> {
+          promise.complete();
+          schedule();
+        });
+      } catch (Exception e) {
+        context.runOnContext(v -> promise.fail(e));
+      }
+    });
+
+    return promise.future();
+  }
+
+  public Future<Set<String>> subscription() {
+    Promise<Set<String>> promise = Promise.promise();
+    worker.submit(() -> {
+      try {
+        Set<String> topics = shareConsumer.subscription();
+        context.runOnContext(v -> promise.complete(topics));
+      } catch (Exception e) {
+        context.runOnContext(v -> promise.fail(e));
+      }
+    });
+    return promise.future();
+  }
+
+  public Future<Void> unsubscribe() {
+    Promise<Void> promise = Promise.promise();
+    worker.submit(() -> {
+      try {
+        shareConsumer.unsubscribe();
+        context.runOnContext(v -> promise.complete());
+      } catch (Exception e) {
+        context.runOnContext(v -> promise.fail(e));
+      }
+    });
+    return promise.future();
+  }
+
+  public Future<ConsumerRecords<K, V>> poll(Duration timeout) {
+    Promise<ConsumerRecords<K, V>> promise = Promise.promise();
+    if (worker == null) {
+      promise.fail(new IllegalStateException("Consumer is not subscribed to any topics"));
+      return promise.future();
+    }
+    worker.submit(() -> {
+      try {
+        ConsumerRecords<K, V> records = shareConsumer.poll(timeout);
+        context.runOnContext(v -> promise.complete(records));
+      } catch (WakeupException ignore) {
+        context.runOnContext(v -> promise.complete(ConsumerRecords.empty()));
+      } catch (Exception e) {
+        context.runOnContext(v -> promise.fail(e));
+      }
+    });
+    return promise.future();
+  }
+
+  /**
+   * Based on Apache Kafka client javadocs, acknowledgment is committed on the next
+   * commitSync(), commitAsync() or poll(Duration) call, so that worker thread
+   * isn't required here.
+   */
+  public Future<Void> acknowledge(ConsumerRecord<K, V> record, AcknowledgeType type) {
+    shareConsumer.acknowledge(record, type);
+    return ((ContextInternal) context).succeededFuture();
+  }
+
+  public Future<Map<TopicIdPartition, Optional<KafkaException>>> commitSync(Duration timeout) {
+    Promise<Map<TopicIdPartition, Optional<KafkaException>>> promise = Promise.promise();
+    worker.submit(() -> {
+      try {
+        Map<TopicIdPartition, Optional<KafkaException>> result = timeout != null
+          ? shareConsumer.commitSync(timeout)
+          : shareConsumer.commitSync();
+        context.runOnContext(v -> promise.complete(result));
+      } catch (Exception e) {
+        context.runOnContext(v -> promise.fail(e));
+      }
+    });
+    return promise.future();
+  }
+
+  public Future<Void> commitSync() {
+    return commitSync(null).flatMap(map -> {
+      List<Map.Entry<TopicIdPartition, KafkaException>> errors = map.entrySet().stream()
+        .filter(e -> e.getValue().isPresent())
+        .map(e -> Map.entry(e.getKey(), e.getValue().get()))
+        .collect(Collectors.toList());
+
+      if (errors.isEmpty()) return Future.succeededFuture();
+      if (errors.size() == 1) return Future.failedFuture(errors.get(0).getValue());
+
+      String message = errors.stream()
+        .map(e ->
+          "[" + e.getKey().topic() + "-" + e.getKey().partition() + ": " + e.getValue().getMessage() + "]"
+        ).collect(Collectors.joining("\n"));
+      return Future.failedFuture(new KafkaException(errors.size() + " partition(s) failed to commit acknowledgements:\n" + message));
+    });
+  }
+
+  public void commitAsync() {
+    worker.submit(() -> {
+      try {
+        shareConsumer.commitAsync();
+      } catch (Exception e) {
+        if (exceptionHandler != null) {
+          context.runOnContext(v -> exceptionHandler.handle(e));
+        }
+      }
+    });
+  }
+
+  public void setAcknowledgementCommitCallback(AcknowledgementCommitCallback callback) {
+    shareConsumer.setAcknowledgementCommitCallback(
+      (offsets, exception) -> context.runOnContext(v -> callback.onComplete(offsets, exception))
+    );
+  }
+
+  public void setPollTimeout(Duration timeout) {
+    this.pollTimeout = timeout;
+  }
+
+  public ShareConsumer<K, V> unwrap() {
+    return shareConsumer;
+  }
+}

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareReadStreamImpl.java
@@ -54,9 +54,12 @@ public class KafkaShareReadStreamImpl<K, V> extends AbstractKafkaReadStreamImpl<
           }
         } catch (WakeupException ignore) {
         } catch (Exception e) {
-          if (exceptionHandler != null) {
-            exceptionHandler.handle(e);
-          }
+          submitted = true;
+          final Handler<Throwable> eh = exceptionHandler;
+          context.runOnContext(v -> {
+            polling.set(false);
+            if (eh != null) eh.handle(e);
+          });
         } finally {
           if (!submitted) {
             context.runOnContext(v -> {

--- a/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareReadStreamImpl.java
+++ b/src/main/java/io/vertx/kafka/client/consumer/impl/KafkaShareReadStreamImpl.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
 package io.vertx.kafka.client.consumer.impl;
 
 import io.vertx.core.Future;

--- a/src/test/java/io/vertx/kafka/client/tests/KafkaStrimziTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/KafkaStrimziTestBase.java
@@ -48,6 +48,13 @@ public abstract class KafkaStrimziTestBase extends KafkaTestBase {
       kafkaConfig.put("super.users", "User:ANONYMOUS");
     }
 
+    // Required for KIP-932 share groups with single broker (__share_group_state to become ready <= 2)
+    kafkaConfig.put("share.coordinator.state.topic.replication.factor", "1");
+    kafkaConfig.put("share.coordinator.state.topic.num.partitions", "1");
+    // Reduce heartbeat interval so share partition initializes faster in tests
+    kafkaConfig.put("group.share.min.heartbeat.interval.ms", "500");
+    kafkaConfig.put("group.share.heartbeat.interval.ms", "1000");
+
     StrimziKafkaCluster strimziCluster = new StrimziKafkaCluster.StrimziKafkaClusterBuilder()
       .withNumberOfBrokers(brokers)
       .withKafkaVersion(KAFKA_VERSION)

--- a/src/test/java/io/vertx/kafka/client/tests/ShareConsumerMockTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ShareConsumerMockTest.java
@@ -1,0 +1,14 @@
+package io.vertx.kafka.client.tests;
+
+import io.vertx.core.Vertx;
+import io.vertx.kafka.client.consumer.KafkaShareConsumer;
+import org.apache.kafka.clients.consumer.ShareConsumer;
+
+public class ShareConsumerMockTest extends ShareConsumerMockTestBase {
+
+  @Override
+  <K, V> KafkaShareConsumer<K, V> createShareConsumer(Vertx vertx, ShareConsumer<K, V> consumer) {
+    return KafkaShareConsumer.create(vertx, consumer);
+  }
+
+}

--- a/src/test/java/io/vertx/kafka/client/tests/ShareConsumerMockTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ShareConsumerMockTest.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
 package io.vertx.kafka.client.tests;
 
 import io.vertx.core.Vertx;

--- a/src/test/java/io/vertx/kafka/client/tests/ShareConsumerMockTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ShareConsumerMockTestBase.java
@@ -1,0 +1,485 @@
+package io.vertx.kafka.client.tests;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.kafka.client.consumer.KafkaShareConsumer;
+import io.vertx.kafka.client.consumer.KafkaShareConsumerRecord;
+import org.apache.kafka.clients.consumer.*;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+@RunWith(VertxUnitRunner.class)
+public abstract class ShareConsumerMockTestBase {
+
+  private Vertx vertx;
+  private final String expectedTopic = "topic-1";
+  private final int expectedPartition = 0;
+  private final String expectedKey = "key-1";
+  private final String expectedValue = "value-1";
+
+  @Before
+  public void beforeTest() {
+    vertx = Vertx.vertx();
+  }
+
+  @After
+  public void afterTest(TestContext ctx) {
+    vertx.close().onComplete(ctx.asyncAssertSuccess());
+  }
+
+  abstract <K, V> KafkaShareConsumer<K, V> createShareConsumer(Vertx vertx, ShareConsumer<K, V> shareConsumer);
+
+  private static class CommitErrorShareConsumer<K, V> extends MockShareConsumer<K, V> {
+    private final Map<TopicIdPartition, Optional<KafkaException>> commitResult;
+
+    CommitErrorShareConsumer(Map<TopicIdPartition, Optional<KafkaException>> commitResult) {
+      this.commitResult = commitResult;
+    }
+
+    @Override
+    public Map<TopicIdPartition, Optional<KafkaException>> commitSync() {
+      return commitResult;
+    }
+
+    @Override
+    public Map<TopicIdPartition, Optional<KafkaException>> commitSync(Duration timeout) {
+      return commitResult;
+    }
+  }
+
+  private static class CallbackShareConsumer<K, V> extends MockShareConsumer<K, V> {
+    protected AcknowledgementCommitCallback callback;
+
+    @Override
+    public void setAcknowledgementCommitCallback(AcknowledgementCommitCallback callback) {
+      this.callback = callback;
+    }
+
+    @Override
+    public void commitAsync() {
+      if (callback != null) {
+        callback.onComplete(Map.of(), null);
+      }
+    }
+  }
+
+  @Test
+  public void testReceiveRecord(TestContext ctx) {
+    var mock = new MockShareConsumer<String, String>();
+    var shareConsumer = createShareConsumer(vertx, mock);
+
+    Async done = ctx.async();
+
+    shareConsumer.exceptionHandler(ctx::fail);
+
+    shareConsumer.handler(record -> {
+      ctx.assertEquals(expectedTopic, record.topic());
+      ctx.assertEquals(expectedPartition, record.partition());
+      ctx.assertEquals(expectedKey, record.key());
+      ctx.assertEquals(expectedValue, record.value());
+      shareConsumer.close().onComplete(v -> done.complete());
+    });
+
+    shareConsumer.subscribe(expectedTopic)
+      .onComplete(ctx.asyncAssertSuccess(v ->
+        mock.addRecord(new ConsumerRecord<>(expectedTopic, expectedPartition, 0L, expectedKey, expectedValue))
+      ));
+  }
+
+  @Test
+  public void testAcknowledgeRecord(TestContext ctx) {
+    MockShareConsumer<String, String> mock = new MockShareConsumer<>();
+    KafkaShareConsumer<String, String> shareConsumer = createShareConsumer(vertx, mock);
+
+    Async done = ctx.async();
+
+    shareConsumer.exceptionHandler(ctx::fail);
+
+    shareConsumer.handler(record -> {
+      shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
+        .onComplete(ctx.asyncAssertSuccess(v ->
+          shareConsumer.close().onComplete(ar -> done.complete())
+        ));
+    });
+
+    shareConsumer.subscribe(expectedTopic)
+      .onComplete(ctx.asyncAssertSuccess(v ->
+        mock.addRecord(new ConsumerRecord<>(expectedTopic, expectedPartition, 0L, expectedKey, expectedValue))
+      ));
+  }
+
+  @Test
+  public void testCommitSync(TestContext ctx) {
+    MockShareConsumer<String, String> mock = new MockShareConsumer<>();
+    KafkaShareConsumer<String, String> shareConsumer = createShareConsumer(vertx, mock);
+
+    Async done = ctx.async();
+
+    shareConsumer.exceptionHandler(ctx::fail);
+
+    shareConsumer.handler(record -> {
+      shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
+        .compose(v -> shareConsumer.commitSync())
+        .onComplete(ctx.asyncAssertSuccess(v ->
+          shareConsumer.close().onComplete(ar -> done.complete())
+        ));
+    });
+
+    shareConsumer.subscribe(expectedTopic)
+      .onComplete(ctx.asyncAssertSuccess(v ->
+        mock.addRecord(new ConsumerRecord<>(expectedTopic, expectedPartition, 0L, expectedKey, expectedValue))
+      ));
+  }
+
+  @Test
+  public void testCommitSyncWithDuration(TestContext ctx) {
+    MockShareConsumer<String, String> mock = new MockShareConsumer<>();
+    KafkaShareConsumer<String, String> shareConsumer = createShareConsumer(vertx, mock);
+
+    Async done = ctx.async();
+
+    shareConsumer.exceptionHandler(ctx::fail);
+
+    shareConsumer.handler(record -> {
+      shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
+        .compose(v -> shareConsumer.commitSync(Duration.ofSeconds(5)))
+        .onComplete(ctx.asyncAssertSuccess(map -> {
+          ctx.assertTrue(map.isEmpty());
+          shareConsumer.close().onComplete(ar -> done.complete());
+        }));
+    });
+
+    shareConsumer.subscribe(expectedTopic)
+      .onComplete(ctx.asyncAssertSuccess(v ->
+        mock.addRecord(new ConsumerRecord<>(expectedTopic, expectedPartition, 0L, expectedKey, expectedValue))
+      ));
+  }
+
+  @Test
+  public void testCommitSyncFailsSingleError(TestContext ctx) {
+    TopicIdPartition tip = new TopicIdPartition(Uuid.randomUuid(), 0, expectedTopic);
+    KafkaException partitionError = new KafkaException("broker rejected");
+
+    CommitErrorShareConsumer<String, String> mock = new CommitErrorShareConsumer<>(
+      Map.of(tip, Optional.of(partitionError))
+    );
+
+    KafkaShareConsumer<String, String> shareConsumer = createShareConsumer(vertx, mock);
+
+    Async done = ctx.async();
+
+    shareConsumer.handler(record -> {
+      shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
+        .compose(v -> shareConsumer.commitSync())
+        .onComplete(ctx.asyncAssertFailure(ex -> {
+          ctx.assertEquals("broker rejected", ex.getMessage());
+          shareConsumer.close().onComplete(ar -> done.complete());
+        }));
+    });
+
+    shareConsumer.subscribe(expectedTopic)
+      .onComplete(ctx.asyncAssertSuccess(v ->
+        mock.addRecord(new ConsumerRecord<>(expectedTopic, expectedPartition, 0L, expectedKey, expectedValue))
+      ));
+  }
+
+  @Test
+  public void testCommitSyncFailsMultipleErrors(TestContext ctx) {
+    TopicIdPartition tip1 = new TopicIdPartition(Uuid.randomUuid(), 0, expectedTopic);
+    TopicIdPartition tip2 = new TopicIdPartition(Uuid.randomUuid(), 1, expectedTopic);
+
+    CommitErrorShareConsumer<String, String> mock = new CommitErrorShareConsumer<>(
+      Map.of(
+        tip1, Optional.of(new KafkaException("error partition 0")),
+        tip2, Optional.of(new KafkaException("error partition 1"))
+      )
+    );
+
+    KafkaShareConsumer<String, String> shareConsumer = createShareConsumer(vertx, mock);
+
+    Async done = ctx.async();
+
+    shareConsumer.handler(record -> {
+      shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
+        .compose(v -> shareConsumer.commitSync())
+        .onComplete(ctx.asyncAssertFailure(ex -> {
+          ctx.assertTrue(ex.getMessage().contains("2 partition(s) failed"));
+          ctx.assertTrue(ex.getMessage().contains(expectedTopic + "-0"));
+          ctx.assertTrue(ex.getMessage().contains(expectedTopic + "-1"));
+          shareConsumer.close().onComplete(ar -> done.complete());
+        }));
+    });
+
+    shareConsumer.subscribe(expectedTopic)
+      .onComplete(ctx.asyncAssertSuccess(v ->
+        mock.addRecord(new ConsumerRecord<>(expectedTopic, expectedPartition, 0L, expectedKey, expectedValue))
+      ));
+  }
+
+  @Test
+  public void testCommitSyncWithDurationExposesErrors(TestContext ctx) {
+    TopicIdPartition tip = new TopicIdPartition(Uuid.randomUuid(), 0, expectedTopic);
+    KafkaException partitionError = new KafkaException("broker rejected");
+
+    CommitErrorShareConsumer<String, String> mock = new CommitErrorShareConsumer<>(
+      Map.of(tip, Optional.of(partitionError))
+    );
+
+    KafkaShareConsumer<String, String> shareConsumer = createShareConsumer(vertx, mock);
+
+    Async done = ctx.async();
+
+    shareConsumer.handler(record -> {
+      shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
+        .compose(v -> shareConsumer.commitSync(Duration.ofSeconds(5)))
+        .onComplete(ctx.asyncAssertSuccess(map -> {
+          ctx.assertEquals(1, map.size());
+          ctx.assertTrue(map.get(tip).isPresent());
+          ctx.assertEquals("broker rejected", map.get(tip).get().getMessage());
+          shareConsumer.close().onComplete(ar -> done.complete());
+        }));
+    });
+
+    shareConsumer.subscribe(expectedTopic)
+      .onComplete(ctx.asyncAssertSuccess(v ->
+        mock.addRecord(new ConsumerRecord<>(expectedTopic, expectedPartition, 0L, expectedKey, expectedValue))
+      ));
+  }
+
+  @Test
+  public void testUnsubscribe(TestContext ctx) {
+    MockShareConsumer<String, String> mock = new MockShareConsumer<>();
+    KafkaShareConsumer<String, String> shareConsumer = createShareConsumer(vertx, mock);
+
+    Async done = ctx.async();
+
+    shareConsumer.exceptionHandler(ctx::fail);
+
+    shareConsumer.subscribe(expectedTopic)
+      .compose(v -> shareConsumer.unsubscribe())
+      .compose(v -> shareConsumer.subscription())
+      .onComplete(ctx.asyncAssertSuccess(topics -> {
+        ctx.assertTrue(topics.isEmpty());
+        shareConsumer.close().onComplete(ar -> done.complete());
+      }));
+  }
+
+  @Test
+  public void testSubscription(TestContext ctx) {
+    MockShareConsumer<String, String> mock = new MockShareConsumer<>();
+    KafkaShareConsumer<String, String> shareConsumer = createShareConsumer(vertx, mock);
+
+    Async done = ctx.async();
+
+    shareConsumer.exceptionHandler(ctx::fail);
+
+    shareConsumer.subscribe(Set.of(expectedTopic, "topic-2"))
+      .compose(v -> shareConsumer.subscription())
+      .onComplete(ctx.asyncAssertSuccess(topics -> {
+        ctx.assertEquals(2, topics.size());
+        ctx.assertTrue(topics.contains(expectedTopic));
+        ctx.assertTrue(topics.contains("topic-2"));
+        shareConsumer.close().onComplete(ar -> done.complete());
+      }));
+  }
+
+  @Test
+  public void testBatchHandler(TestContext ctx) {
+    MockShareConsumer<String, String> mock = new MockShareConsumer<>();
+    KafkaShareConsumer<String, String> shareConsumer = createShareConsumer(vertx, mock);
+
+    Async done = ctx.async();
+
+    shareConsumer.exceptionHandler(ctx::fail);
+
+    shareConsumer.batchHandler(records -> {
+      ctx.assertEquals(2, records.size());
+      ctx.assertEquals(expectedKey, records.recordAt(0).key());
+      ctx.assertEquals("key-2", records.recordAt(1).key());
+      shareConsumer.close().onComplete(ar -> done.complete());
+    });
+
+    shareConsumer.subscribe(expectedTopic)
+      .onComplete(ctx.asyncAssertSuccess(v -> {
+        mock.addRecord(new ConsumerRecord<>(expectedTopic, expectedPartition, 0L, expectedKey, expectedValue));
+        mock.addRecord(new ConsumerRecord<>(expectedTopic, expectedPartition, 1L, "key-2", "value-2"));
+      }));
+  }
+
+  @Test
+  public void testEndHandler(TestContext ctx) {
+    MockShareConsumer<String, String> mock = new MockShareConsumer<>();
+    KafkaShareConsumer<String, String> shareConsumer = createShareConsumer(vertx, mock);
+
+    Async done = ctx.async();
+
+    shareConsumer.exceptionHandler(ctx::fail);
+    shareConsumer.endHandler(v -> done.complete());
+
+    shareConsumer.subscribe(expectedTopic)
+      .compose(v -> shareConsumer.close());
+  }
+
+  @Test
+  public void testManualPoll(TestContext ctx) {
+    MockShareConsumer<String, String> mock = new MockShareConsumer<>();
+    KafkaShareConsumer<String, String> shareConsumer = createShareConsumer(vertx, mock);
+
+    Async done = ctx.async();
+
+    shareConsumer.exceptionHandler(ctx::fail);
+
+    shareConsumer.subscribe(expectedTopic)
+      .onComplete(ctx.asyncAssertSuccess(v -> {
+        mock.addRecord(new ConsumerRecord<>(expectedTopic, expectedPartition, 0L, expectedKey, expectedValue));
+        shareConsumer.poll(Duration.ofSeconds(1))
+          .onComplete(ctx.asyncAssertSuccess(records -> {
+            ctx.assertEquals(1, records.size());
+            KafkaShareConsumerRecord<String, String> record = records.recordAt(0);
+            ctx.assertEquals(expectedTopic, record.topic());
+            ctx.assertEquals(expectedKey, record.key());
+            ctx.assertEquals(expectedValue, record.value());
+            shareConsumer.close().onComplete(ar -> done.complete());
+          }));
+      }));
+  }
+
+  @Test
+  public void testCommitAsyncCallbackFires(TestContext ctx) {
+    CallbackShareConsumer<String, String> mock = new CallbackShareConsumer<>();
+    KafkaShareConsumer<String, String> shareConsumer = createShareConsumer(vertx, mock);
+
+    Async done = ctx.async();
+
+    shareConsumer.setAcknowledgementCommitCallback((offsets, exception) -> {
+      ctx.assertNull(exception);
+      shareConsumer.close().onComplete(ar -> done.complete());
+    });
+
+    shareConsumer.handler(record -> {
+      shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT);
+      shareConsumer.commitAsync();
+    });
+
+    shareConsumer.subscribe(expectedTopic)
+      .onComplete(ctx.asyncAssertSuccess(v ->
+        mock.addRecord(new ConsumerRecord<>(expectedTopic, expectedPartition, 0L, expectedKey, expectedValue))
+      ));
+  }
+
+  @Test
+  public void testCommitAsyncCallbackWithError(TestContext ctx) {
+    KafkaException commitError = new KafkaException("async commit failed");
+    CallbackShareConsumer<String, String> mock = new CallbackShareConsumer<>() {
+      @Override
+      public void commitAsync() {
+        if (callback != null) {
+          callback.onComplete(Map.of(), commitError);
+        }
+      }
+    };
+
+    KafkaShareConsumer<String, String> shareConsumer = createShareConsumer(vertx, mock);
+    Async done = ctx.async();
+
+    shareConsumer.setAcknowledgementCommitCallback((offsets, exception) -> {
+      ctx.assertNotNull(exception);
+      ctx.assertEquals("async commit failed", exception.getMessage());
+      shareConsumer.close().onComplete(ar -> done.complete());
+    });
+
+    shareConsumer.handler(record -> shareConsumer.commitAsync());
+
+    shareConsumer.subscribe(expectedTopic)
+      .onComplete(ctx.asyncAssertSuccess(v ->
+        mock.addRecord(new ConsumerRecord<>(expectedTopic, expectedPartition, 0L, expectedKey, expectedValue))
+      ));
+  }
+
+  @Test
+  public void testPollTimeout(TestContext ctx) {
+    MockShareConsumer<String, String> mock = new MockShareConsumer<>();
+    KafkaShareConsumer<String, String> shareConsumer = createShareConsumer(vertx, mock);
+
+    Async done = ctx.async();
+
+    shareConsumer.exceptionHandler(ctx::fail);
+
+    shareConsumer.pollTimeout(Duration.ofMillis(500));
+
+    shareConsumer.handler(record -> {
+      ctx.assertEquals(expectedValue, record.value());
+      shareConsumer.close().onComplete(ar -> done.complete());
+    });
+
+    shareConsumer.subscribe(expectedTopic)
+      .onComplete(ctx.asyncAssertSuccess(v ->
+        mock.addRecord(new ConsumerRecord<>(expectedTopic, expectedPartition, 0L, expectedKey, expectedValue))
+      ));
+  }
+
+  @Test
+  public void testUnwrap(TestContext ctx) {
+    MockShareConsumer<String, String> mock = new MockShareConsumer<>();
+    KafkaShareConsumer<String, String> shareConsumer = createShareConsumer(vertx, mock);
+
+    ctx.assertEquals(mock, shareConsumer.unwrap());
+  }
+
+  @Test
+  public void testPause(TestContext ctx) {
+    MockShareConsumer<String, String> mock = new MockShareConsumer<>();
+    KafkaShareConsumer<String, String> shareConsumer = createShareConsumer(vertx, mock);
+
+    Async done = ctx.async();
+    shareConsumer.exceptionHandler(ctx::fail);
+
+    shareConsumer.pause();
+
+    shareConsumer.handler(record -> ctx.fail("handler should not be called while paused"));
+
+    shareConsumer.subscribe(expectedTopic)
+      .onComplete(ctx.asyncAssertSuccess(v -> {
+        mock.addRecord(new ConsumerRecord<>(expectedTopic, expectedPartition, 0L, expectedKey, expectedValue));
+        // wait briefly, then verify no record was delivered
+        vertx.setTimer(300, t -> {
+          shareConsumer.close().onComplete(ar -> done.complete());
+        });
+      }));
+  }
+
+  @Test
+  public void testResumeAfterPause(TestContext ctx) {
+    MockShareConsumer<String, String> mock = new MockShareConsumer<>();
+    KafkaShareConsumer<String, String> shareConsumer = createShareConsumer(vertx, mock);
+
+    Async done = ctx.async();
+    shareConsumer.exceptionHandler(ctx::fail);
+
+    shareConsumer.pause();
+
+    shareConsumer.handler(record -> {
+      ctx.assertEquals(expectedValue, record.value());
+      shareConsumer.close().onComplete(ar -> done.complete());
+    });
+
+    shareConsumer.subscribe(expectedTopic)
+      .onComplete(ctx.asyncAssertSuccess(v -> {
+        mock.addRecord(new ConsumerRecord<>(expectedTopic, expectedPartition, 0L, expectedKey, expectedValue));
+        vertx.setTimer(100, t -> shareConsumer.resume());
+      }));
+  }
+
+}

--- a/src/test/java/io/vertx/kafka/client/tests/ShareConsumerMockTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ShareConsumerMockTestBase.java
@@ -107,12 +107,10 @@ public abstract class ShareConsumerMockTestBase {
 
     shareConsumer.exceptionHandler(ctx::fail);
 
-    shareConsumer.handler(record -> {
-      shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
-        .onComplete(ctx.asyncAssertSuccess(v ->
-          shareConsumer.close().onComplete(ar -> done.complete())
-        ));
-    });
+    shareConsumer.handler(record -> shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
+      .onComplete(ctx.asyncAssertSuccess(v ->
+        shareConsumer.close().onComplete(ar -> done.complete())
+      )));
 
     shareConsumer.subscribe(expectedTopic)
       .onComplete(ctx.asyncAssertSuccess(v ->
@@ -129,13 +127,11 @@ public abstract class ShareConsumerMockTestBase {
 
     shareConsumer.exceptionHandler(ctx::fail);
 
-    shareConsumer.handler(record -> {
-      shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
-        .compose(v -> shareConsumer.commitSync())
-        .onComplete(ctx.asyncAssertSuccess(v ->
-          shareConsumer.close().onComplete(ar -> done.complete())
-        ));
-    });
+    shareConsumer.handler(record -> shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
+      .compose(v -> shareConsumer.commitSync())
+      .onComplete(ctx.asyncAssertSuccess(v ->
+        shareConsumer.close().onComplete(ar -> done.complete())
+      )));
 
     shareConsumer.subscribe(expectedTopic)
       .onComplete(ctx.asyncAssertSuccess(v ->
@@ -152,14 +148,12 @@ public abstract class ShareConsumerMockTestBase {
 
     shareConsumer.exceptionHandler(ctx::fail);
 
-    shareConsumer.handler(record -> {
-      shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
-        .compose(v -> shareConsumer.commitSync(Duration.ofSeconds(5)))
-        .onComplete(ctx.asyncAssertSuccess(map -> {
-          ctx.assertTrue(map.isEmpty());
-          shareConsumer.close().onComplete(ar -> done.complete());
-        }));
-    });
+    shareConsumer.handler(record -> shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
+      .compose(v -> shareConsumer.commitSync(Duration.ofSeconds(5)))
+      .onComplete(ctx.asyncAssertSuccess(map -> {
+        ctx.assertTrue(map.isEmpty());
+        shareConsumer.close().onComplete(ar -> done.complete());
+      })));
 
     shareConsumer.subscribe(expectedTopic)
       .onComplete(ctx.asyncAssertSuccess(v ->
@@ -180,14 +174,12 @@ public abstract class ShareConsumerMockTestBase {
 
     Async done = ctx.async();
 
-    shareConsumer.handler(record -> {
-      shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
-        .compose(v -> shareConsumer.commitSync())
-        .onComplete(ctx.asyncAssertFailure(ex -> {
-          ctx.assertEquals("broker rejected", ex.getMessage());
-          shareConsumer.close().onComplete(ar -> done.complete());
-        }));
-    });
+    shareConsumer.handler(record -> shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
+      .compose(v -> shareConsumer.commitSync())
+      .onComplete(ctx.asyncAssertFailure(ex -> {
+        ctx.assertEquals("broker rejected", ex.getMessage());
+        shareConsumer.close().onComplete(ar -> done.complete());
+      })));
 
     shareConsumer.subscribe(expectedTopic)
       .onComplete(ctx.asyncAssertSuccess(v ->
@@ -211,16 +203,14 @@ public abstract class ShareConsumerMockTestBase {
 
     Async done = ctx.async();
 
-    shareConsumer.handler(record -> {
-      shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
-        .compose(v -> shareConsumer.commitSync())
-        .onComplete(ctx.asyncAssertFailure(ex -> {
-          ctx.assertTrue(ex.getMessage().contains("2 partition(s) failed"));
-          ctx.assertTrue(ex.getMessage().contains(expectedTopic + "-0"));
-          ctx.assertTrue(ex.getMessage().contains(expectedTopic + "-1"));
-          shareConsumer.close().onComplete(ar -> done.complete());
-        }));
-    });
+    shareConsumer.handler(record -> shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
+      .compose(v -> shareConsumer.commitSync())
+      .onComplete(ctx.asyncAssertFailure(ex -> {
+        ctx.assertTrue(ex.getMessage().contains("2 partition(s) failed"));
+        ctx.assertTrue(ex.getMessage().contains(expectedTopic + "-0"));
+        ctx.assertTrue(ex.getMessage().contains(expectedTopic + "-1"));
+        shareConsumer.close().onComplete(ar -> done.complete());
+      })));
 
     shareConsumer.subscribe(expectedTopic)
       .onComplete(ctx.asyncAssertSuccess(v ->
@@ -241,16 +231,14 @@ public abstract class ShareConsumerMockTestBase {
 
     Async done = ctx.async();
 
-    shareConsumer.handler(record -> {
-      shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
-        .compose(v -> shareConsumer.commitSync(Duration.ofSeconds(5)))
-        .onComplete(ctx.asyncAssertSuccess(map -> {
-          ctx.assertEquals(1, map.size());
-          ctx.assertTrue(map.get(tip).isPresent());
-          ctx.assertEquals("broker rejected", map.get(tip).get().getMessage());
-          shareConsumer.close().onComplete(ar -> done.complete());
-        }));
-    });
+    shareConsumer.handler(record -> shareConsumer.acknowledge(record, AcknowledgeType.ACCEPT)
+      .compose(v -> shareConsumer.commitSync(Duration.ofSeconds(5)))
+      .onComplete(ctx.asyncAssertSuccess(map -> {
+        ctx.assertEquals(1, map.size());
+        ctx.assertTrue(map.get(tip).isPresent());
+        ctx.assertEquals("broker rejected", map.get(tip).get().getMessage());
+        shareConsumer.close().onComplete(ar -> done.complete());
+      })));
 
     shareConsumer.subscribe(expectedTopic)
       .onComplete(ctx.asyncAssertSuccess(v ->
@@ -454,9 +442,7 @@ public abstract class ShareConsumerMockTestBase {
       .onComplete(ctx.asyncAssertSuccess(v -> {
         mock.addRecord(new ConsumerRecord<>(expectedTopic, expectedPartition, 0L, expectedKey, expectedValue));
         // wait briefly, then verify no record was delivered
-        vertx.setTimer(300, t -> {
-          shareConsumer.close().onComplete(ar -> done.complete());
-        });
+        vertx.setTimer(300, t -> shareConsumer.close().onComplete(ar -> done.complete()));
       }));
   }
 

--- a/src/test/java/io/vertx/kafka/client/tests/ShareConsumerMockTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ShareConsumerMockTestBase.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
 package io.vertx.kafka.client.tests;
 
 import io.vertx.core.Vertx;

--- a/src/test/java/io/vertx/kafka/client/tests/ShareConsumerTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ShareConsumerTest.java
@@ -1,0 +1,17 @@
+package io.vertx.kafka.client.tests;
+
+import io.vertx.core.Vertx;
+import io.vertx.kafka.client.consumer.KafkaShareConsumer;
+
+import java.util.Properties;
+
+/**
+ * Integration tests for {@link KafkaShareConsumer} against a real Kafka cluster.
+ */
+public class ShareConsumerTest extends ShareConsumerTestBase {
+
+  @Override
+  protected KafkaShareConsumer<String, String> createShareConsumer(Vertx vertx, Properties config) {
+    return KafkaShareConsumer.create(vertx, config);
+  }
+}

--- a/src/test/java/io/vertx/kafka/client/tests/ShareConsumerTest.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ShareConsumerTest.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
 package io.vertx.kafka.client.tests;
 
 import io.vertx.core.Vertx;

--- a/src/test/java/io/vertx/kafka/client/tests/ShareConsumerTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ShareConsumerTestBase.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
 package io.vertx.kafka.client.tests;
 
 import io.vertx.core.Vertx;

--- a/src/test/java/io/vertx/kafka/client/tests/ShareConsumerTestBase.java
+++ b/src/test/java/io/vertx/kafka/client/tests/ShareConsumerTestBase.java
@@ -1,0 +1,476 @@
+package io.vertx.kafka.client.tests;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.kafka.client.consumer.KafkaShareConsumer;
+import org.apache.kafka.clients.consumer.AcknowledgeType;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Base class for KafkaShareConsumer integration tests against a real Kafka cluster.
+ * <p>
+ * All tests here exercise behavior that is common across share consumer implementations.
+ * Subclasses only implement {@link #createShareConsumer} to choose the factory under test.
+ */
+public abstract class ShareConsumerTestBase extends KafkaStrimziTestBase {
+
+  /*
+   * Share groups initialize the share partition on the first heartbeat cycle.
+   * With group.share.heartbeat.interval.ms=1000 in the test cluster the assignment arrives at ~1s.
+   * We wait 2s before producing so the partition is already initialized on an empty topic (start offset = 0),
+   * making messages at offset 0+ visible to the share consumer.
+   */
+  private static final long SHARE_GROUP_INIT_DELAY_MS = 4000L;
+
+  protected Vertx vertx;
+  protected KafkaShareConsumer<String, String> consumer;
+
+  @Before
+  public void beforeTest() {
+    vertx = Vertx.vertx();
+  }
+
+  @After
+  public void afterTest(TestContext ctx) {
+    if (consumer != null) {
+      Async closeAsync = ctx.async();
+      consumer.close().onComplete(ar -> closeAsync.complete());
+      closeAsync.awaitSuccess(10000);
+      consumer = null;
+    }
+    vertx.close().onComplete(ctx.asyncAssertSuccess());
+  }
+
+  /**
+   * Build share consumer properties for the given share group and client ID.
+   * Unlike regular consumers, share groups do not use {@code auto.offset.reset},
+   * the share coordinator manages delivery state in __share_group_state topic
+   * and initializes the start offset on the first heartbeat.
+   */
+  protected Properties shareConsumerProperties(String groupId, String clientId) {
+    return shareConsumerProperties(groupId, clientId, false);
+  }
+
+  protected Properties shareConsumerProperties(String groupId, String clientId, boolean explicitAck) {
+    Properties props = new Properties();
+    props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaCluster.getBootstrapServers());
+    if (groupId != null) props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+    props.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+    props.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+    if (clientId != null) {
+      props.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
+    }
+    if (explicitAck) {
+      props.setProperty("share.acknowledgement.mode", "explicit");
+    }
+    return props;
+  }
+
+  /**
+   * Create the {@link KafkaShareConsumer} under test.
+   * Concrete subclasses choose the factory method / options to exercise.
+   */
+  protected abstract KafkaShareConsumer<String, String> createShareConsumer(Vertx vertx, Properties config);
+
+  @Test
+  public void testConsume(TestContext ctx) {
+    String topicName = "testShareConsume-" + this.getClass().getName();
+    int numMessages = 100;
+
+    kafkaCluster.createTopic(topicName, 1, 1);
+
+    consumer = createShareConsumer(vertx, shareConsumerProperties(topicName, topicName));
+    Async done = ctx.async();
+    AtomicInteger count = new AtomicInteger(numMessages);
+    consumer.exceptionHandler(ctx::fail);
+    consumer.handler(rec -> {
+      if (count.decrementAndGet() == 0) {
+        done.complete();
+      }
+    });
+    consumer.subscribe(Collections.singleton(topicName)).onComplete(ar -> {
+      ctx.assertTrue(ar.succeeded());
+      vertx.setTimer(SHARE_GROUP_INIT_DELAY_MS, t -> {
+        AtomicInteger index = new AtomicInteger();
+        kafkaCluster.useTo().produceStrings(numMessages, () -> {
+        }, () ->
+          new ProducerRecord<>(topicName, "key-" + index.get(), "value-" + index.getAndIncrement()));
+      });
+    });
+  }
+
+  @Test
+  public void testConsumeWithHeaders(TestContext ctx) {
+    String topicName = "testShareConsumeWithHeaders-" + this.getClass().getName();
+    int numMessages = 50;
+
+    kafkaCluster.createTopic(topicName, 1, 1);
+
+    consumer = createShareConsumer(vertx, shareConsumerProperties(topicName, topicName));
+    Async done = ctx.async();
+    AtomicInteger count = new AtomicInteger(numMessages);
+    AtomicInteger headerIndex = new AtomicInteger();
+    consumer.exceptionHandler(ctx::fail);
+    consumer.handler(rec -> {
+      ctx.assertEquals(1, rec.headers().size());
+      ctx.assertEquals("hk-" + headerIndex.get(), rec.headers().get(0).key());
+      ctx.assertEquals("hv-" + headerIndex.getAndIncrement(), rec.headers().get(0).value().toString());
+      if (count.decrementAndGet() == 0) {
+        done.complete();
+      }
+    });
+    consumer.subscribe(Collections.singleton(topicName)).onComplete(ar -> {
+      ctx.assertTrue(ar.succeeded());
+      vertx.setTimer(SHARE_GROUP_INIT_DELAY_MS, t -> {
+        AtomicInteger index = new AtomicInteger();
+        kafkaCluster.useTo().produceStrings(numMessages, () -> {
+        }, () ->
+          new ProducerRecord<>(topicName, 0, "key-" + index.get(), "value-" + index.get(),
+            Collections.singletonList(
+              new org.apache.kafka.common.header.internals.RecordHeader(
+                "hk-" + index.get(), ("hv-" + index.getAndIncrement()).getBytes()))));
+      });
+    });
+  }
+
+  @Test
+  public void testPause(TestContext ctx) {
+    String topicName = "testSharePause-" + this.getClass().getName();
+    int numMessages = 100;
+
+    kafkaCluster.createTopic(topicName, 1, 1);
+
+    consumer = createShareConsumer(vertx, shareConsumerProperties(topicName, topicName));
+    Async done = ctx.async();
+    AtomicInteger count = new AtomicInteger(numMessages);
+    AtomicBoolean paused = new AtomicBoolean();
+    consumer.exceptionHandler(ctx::fail);
+    consumer.handler(rec -> {
+      ctx.assertFalse(paused.get());
+      int val = count.decrementAndGet();
+      if (val == numMessages / 2) {
+        paused.set(true);
+        consumer.pause();
+        vertx.setTimer(500, id -> {
+          paused.set(false);
+          consumer.resume();
+        });
+      }
+      if (val == 0) {
+        done.complete();
+      }
+    });
+    consumer.subscribe(Collections.singleton(topicName)).onComplete(ar -> {
+      ctx.assertTrue(ar.succeeded());
+      vertx.setTimer(SHARE_GROUP_INIT_DELAY_MS, t -> {
+        AtomicInteger index = new AtomicInteger();
+        kafkaCluster.useTo().produceStrings(numMessages, () -> {
+        }, () ->
+          new ProducerRecord<>(topicName, "key-" + index.get(), "value-" + index.getAndIncrement()));
+      });
+    });
+  }
+
+  @Test
+  public void testFetch(TestContext ctx) {
+    String topicName = "testShareFetch-" + this.getClass().getName();
+    int numMessages = 100;
+    long batchSize = 20L;
+
+    kafkaCluster.createTopic(topicName, 1, 1);
+
+    consumer = createShareConsumer(vertx, shareConsumerProperties(topicName, topicName));
+    Async done = ctx.async();
+    AtomicInteger count = new AtomicInteger(numMessages);
+    AtomicLong demand = new AtomicLong();
+    consumer.exceptionHandler(ctx::fail);
+    consumer.handler(rec -> {
+      long remaining = demand.decrementAndGet();
+      ctx.assertTrue(remaining >= 0L);
+      if (remaining == 0L) {
+        vertx.setTimer(200, id -> {
+          demand.set(batchSize);
+          consumer.fetch(batchSize);
+        });
+      }
+      if (count.decrementAndGet() == 0) {
+        done.complete();
+      }
+    });
+
+    consumer.pause();
+    demand.set(batchSize);
+    consumer.fetch(batchSize);
+    consumer.subscribe(Collections.singleton(topicName)).onComplete(ar -> {
+      ctx.assertTrue(ar.succeeded());
+      vertx.setTimer(SHARE_GROUP_INIT_DELAY_MS, t -> {
+        AtomicInteger index = new AtomicInteger();
+        kafkaCluster.useTo().produceStrings(numMessages, () -> {
+        }, () ->
+          new ProducerRecord<>(topicName, "key-" + index.get(), "value-" + index.getAndIncrement()));
+      });
+    });
+  }
+
+  @Test
+  public void testSubscription(TestContext ctx) {
+    String topicName = "testShareSubscription-" + this.getClass().getName();
+    kafkaCluster.createTopic(topicName, 1, 1);
+
+    consumer = createShareConsumer(vertx, shareConsumerProperties(topicName, topicName));
+    Async done = ctx.async();
+    consumer.exceptionHandler(ctx::fail);
+    consumer.subscribe(Collections.singleton(topicName)).onComplete(ar -> {
+      ctx.assertTrue(ar.succeeded());
+      consumer.subscription().onComplete(subAr -> {
+        ctx.assertTrue(subAr.succeeded());
+        ctx.assertTrue(subAr.result().contains(topicName));
+        done.complete();
+      });
+    });
+  }
+
+  @Test
+  public void testBatchHandler(TestContext ctx) {
+    String topicName = "testShareBatchHandler-" + this.getClass().getName();
+    int numMessages = 50;
+
+    kafkaCluster.createTopic(topicName, 1, 1);
+
+    consumer = createShareConsumer(vertx, shareConsumerProperties(topicName, topicName));
+    Async done = ctx.async();
+    AtomicInteger count = new AtomicInteger();
+    consumer.exceptionHandler(ctx::fail);
+    consumer.batchHandler(records -> {
+      count.addAndGet(records.size());
+      if (count.get() >= numMessages) {
+        done.complete();
+      }
+    });
+    consumer.subscribe(Collections.singleton(topicName)).onComplete(ar -> {
+      ctx.assertTrue(ar.succeeded());
+      vertx.setTimer(SHARE_GROUP_INIT_DELAY_MS, t -> {
+        AtomicInteger index = new AtomicInteger();
+        kafkaCluster.useTo().produceStrings(numMessages, () -> {
+        }, () ->
+          new ProducerRecord<>(topicName, "key-" + index.get(), "value-" + index.getAndIncrement()));
+      });
+    });
+  }
+
+  @Test
+  public void testPollTimeout(TestContext ctx) {
+    String topicName = "testSharePollTimeout-" + this.getClass().getName();
+    kafkaCluster.createTopic(topicName, 1, 1);
+
+    consumer = createShareConsumer(vertx, shareConsumerProperties(topicName, topicName));
+    Duration timeout = Duration.ofMillis(500);
+    consumer.pollTimeout(timeout);
+
+    Async done = ctx.async();
+    consumer.exceptionHandler(ctx::fail);
+    consumer.subscribe(Collections.singleton(topicName)).onComplete(ar -> {
+      ctx.assertTrue(ar.succeeded());
+      long before = System.currentTimeMillis();
+      consumer.poll(timeout).onComplete(pollAr -> {
+        ctx.assertTrue(pollAr.succeeded());
+        ctx.assertTrue(pollAr.result().isEmpty());
+        long elapsed = System.currentTimeMillis() - before;
+        ctx.assertTrue(elapsed >= timeout.toMillis(),
+          "poll() must block at least as long as the timeout, got " + elapsed + "ms");
+        done.complete();
+      });
+    });
+  }
+
+  @Test
+  public void testConsumeWithPoll(TestContext ctx) {
+    String topicName = "testShareConsumeWithPoll-" + this.getClass().getName();
+    int numMessages = 50;
+
+    kafkaCluster.createTopic(topicName, 1, 1);
+
+    consumer = createShareConsumer(vertx, shareConsumerProperties(topicName, topicName));
+    Async done = ctx.async();
+    AtomicInteger count = new AtomicInteger(numMessages);
+    consumer.exceptionHandler(ctx::fail);
+    consumer.subscribe(Collections.singleton(topicName)).onComplete(ar -> {
+      ctx.assertTrue(ar.succeeded());
+      // Start polling immediately so heartbeats drive share partition initialization.
+      // Produce after the init delay so records land at offset 0+ (after start offset is set).
+      AtomicInteger index = new AtomicInteger();
+      AtomicLong timerId = new AtomicLong();
+      timerId.set(vertx.setPeriodic(1000, t -> {
+        consumer.poll(Duration.ofMillis(500))
+          .onComplete(pollAr -> {
+            if (pollAr.succeeded()) {
+              if (count.addAndGet(-pollAr.result().size()) <= 0) {
+                vertx.cancelTimer(timerId.get());
+                done.complete();
+              }
+            } else {
+              ctx.fail(pollAr.cause());
+            }
+          });
+      }));
+      vertx.setTimer(SHARE_GROUP_INIT_DELAY_MS, t ->
+        kafkaCluster.useTo().produceStrings(numMessages, () -> {
+        }, () ->
+          new ProducerRecord<>(topicName, "key-" + index.get(), "value-" + index.getAndIncrement())));
+    });
+  }
+
+  @Test
+  public void testConsumeWithPollNoMessages(TestContext ctx) {
+    String topicName = "testShareConsumeWithPollNoMessages-" + this.getClass().getName();
+    kafkaCluster.createTopic(topicName, 1, 1);
+
+    consumer = createShareConsumer(vertx, shareConsumerProperties(topicName, topicName));
+    Async done = ctx.async();
+    AtomicInteger emptyPolls = new AtomicInteger(3);
+    consumer.exceptionHandler(ctx::fail);
+    consumer.subscribe(Collections.singleton(topicName)).onComplete(ar -> {
+      ctx.assertTrue(ar.succeeded());
+      vertx.setPeriodic(500, t -> {
+        consumer.poll(Duration.ofMillis(100)).onComplete(pollAr -> {
+          if (pollAr.succeeded()) {
+            ctx.assertTrue(pollAr.result().isEmpty(), "expected no records on empty topic");
+            if (emptyPolls.decrementAndGet() == 0) {
+              vertx.cancelTimer(t);
+              done.complete();
+            }
+          } else {
+            ctx.fail(pollAr.cause());
+          }
+        });
+      });
+    });
+  }
+
+  @Test
+  public void testPollNoSubscribe(TestContext ctx) {
+    consumer = createShareConsumer(vertx, shareConsumerProperties("testSharePollNoSub", null));
+    Async done = ctx.async();
+    consumer.poll(Duration.ofMillis(100)).onComplete(ar -> {
+      ctx.assertTrue(ar.failed());
+      ctx.assertTrue(ar.cause() instanceof IllegalStateException);
+      done.complete();
+    });
+  }
+
+  @Test
+  public void testAcknowledgeAndCommitSync(TestContext ctx) {
+    String topicName = "testShareAckCommitSync-" + this.getClass().getName();
+    int numMessages = 10;
+
+    kafkaCluster.createTopic(topicName, 1, 1);
+
+    consumer = createShareConsumer(vertx, shareConsumerProperties(topicName, topicName, true));
+    Async done = ctx.async();
+    AtomicInteger count = new AtomicInteger(numMessages);
+    consumer.exceptionHandler(ctx::fail);
+    consumer.handler(rec -> {
+      consumer.acknowledge(rec, AcknowledgeType.ACCEPT).onComplete(ackAr -> {
+        ctx.assertTrue(ackAr.succeeded());
+        consumer.commitSync().onComplete(commitAr -> {
+          ctx.assertTrue(commitAr.succeeded());
+          if (count.decrementAndGet() == 0) {
+            done.complete();
+          }
+        });
+      });
+    });
+    consumer.subscribe(Collections.singleton(topicName)).onComplete(ar -> {
+      ctx.assertTrue(ar.succeeded());
+      vertx.setTimer(SHARE_GROUP_INIT_DELAY_MS, t -> {
+        AtomicInteger index = new AtomicInteger();
+        kafkaCluster.useTo().produceStrings(numMessages, () -> {
+        }, () ->
+          new ProducerRecord<>(topicName, "key-" + index.get(), "value-" + index.getAndIncrement()));
+      });
+    });
+  }
+
+  @Test
+  public void testAcknowledgeRelease(TestContext ctx) {
+    String topicName = "testShareAckRelease-" + this.getClass().getName();
+
+    kafkaCluster.createTopic(topicName, 1, 1);
+
+    consumer = createShareConsumer(vertx, shareConsumerProperties(topicName, topicName, true));
+    Async done = ctx.async();
+    AtomicInteger deliveries = new AtomicInteger();
+    consumer.exceptionHandler(ctx::fail);
+    consumer.handler(rec -> {
+      int delivery = deliveries.incrementAndGet();
+      if (delivery == 1) {
+        consumer.acknowledge(rec, AcknowledgeType.RELEASE).onComplete(ar ->
+          ctx.assertTrue(ar.succeeded()));
+      } else {
+        consumer.acknowledge(rec, AcknowledgeType.ACCEPT).onComplete(ar -> {
+          ctx.assertTrue(ar.succeeded());
+          done.complete();
+        });
+      }
+    });
+    consumer.subscribe(Collections.singleton(topicName)).onComplete(ar -> {
+      ctx.assertTrue(ar.succeeded());
+      vertx.setTimer(SHARE_GROUP_INIT_DELAY_MS, t ->
+        kafkaCluster.useTo().produceStrings(1, () -> {
+        }, () ->
+          new ProducerRecord<>(topicName, "key", "value")));
+    });
+  }
+
+  @Test
+  public void testCommitAsync(TestContext ctx) {
+    String topicName = "testShareCommitAsync-" + this.getClass().getName();
+    int numMessages = 10;
+
+    kafkaCluster.createTopic(topicName, 1, 1);
+
+    consumer = createShareConsumer(vertx, shareConsumerProperties(topicName, topicName, true));
+    Async done = ctx.async();
+    AtomicInteger count = new AtomicInteger(numMessages);
+    consumer.exceptionHandler(ctx::fail);
+    consumer.setAcknowledgementCommitCallback((offsets, exception) -> {
+      ctx.assertNull(exception);
+      int acked = offsets.values().stream().mapToInt(Set::size).sum();
+      if (count.addAndGet(-acked) <= 0) done.complete();
+    });
+    consumer.handler(rec -> {
+      consumer.acknowledge(rec, AcknowledgeType.ACCEPT);
+      consumer.commitAsync();
+    });
+    consumer.subscribe(Collections.singleton(topicName)).onComplete(ar -> {
+      ctx.assertTrue(ar.succeeded());
+      vertx.setTimer(SHARE_GROUP_INIT_DELAY_MS, t -> {
+        AtomicInteger index = new AtomicInteger();
+        kafkaCluster.useTo().produceStrings(numMessages, () -> {
+        }, () ->
+          new ProducerRecord<>(topicName, "key-" + index.get(), "value-" + index.getAndIncrement()));
+      });
+    });
+  }
+
+  @Test(expected = org.apache.kafka.common.KafkaException.class)
+  public void testPollExceptionHandler(TestContext ctx) {
+    Properties config = shareConsumerProperties(null, null);
+    config.remove(ConsumerConfig.GROUP_ID_CONFIG);
+    consumer = createShareConsumer(vertx, config);
+  }
+}


### PR DESCRIPTION
Motivation:

Adds KafkaShareConsumer<K, V> as a Vert.x wrapper around the native KafkaShareConsumer introduced in KIP-932.
Current implementation allows multiple consumers to cooperatively consume the same partitions without exclusive ownership.

What's in this PR:
- KafkaShareConsumer interface and factory mirroring the existing KafkaConsumer API style
- KafkaShareConsumerRecord extends KafkaConsumerRecord with delivery count
- KafkaShareReadStreamImpl implements Kafka operations on dedicated single-threaded worker
- AbstractKafkaReadStreamImpl implements common Kafka ReadStream logic (in the future can be used by both implementations)
- Unit test contracts (mocks)
- Integration test with Strimzi

Not yet done:
- [ ] Documentation and examples

Open questions:
- acknowledge method exposed by KafkaShareConsumer uses org.apache.kafka.clients.consumer.AcknowledgeType which cannot be generated (@VertxGen). Should we create a specific Vert.x copy of this enum or should we ignore it? 
- does AbstractKafkaReadStreamImpl make sense as super class for both standard and share consumer?
- I added ThreadFactory as KafkaShareConsumer factory parameter. Intention is to use it with virtual threads (JDK 21+). I tried it locally without pushing sources as pom.xml is still stuck on JDK 11. It's ok to have it as experimental feature?
- Running any Maven command (install, test) deletes files from src/main/generated/ without regenerating them. Is the codegen processor expected to run locally, or are these files meant to be manually maintained and committed?

Conformance:
- Eclipse Contributor Agreement signed. 
- Code follows the Vert.x style guidelines.